### PR TITLE
[tests] cleanup resources

### DIFF
--- a/test/acceptance/coffee/FilestoreApp.coffee
+++ b/test/acceptance/coffee/FilestoreApp.coffee
@@ -2,10 +2,12 @@ app = require('../../../app')
 require("logger-sharelatex").logger.level("info")
 logger = require("logger-sharelatex")
 Settings = require("settings-sharelatex")
+Metrics = require("metrics-sharelatex")
 
 module.exports =
 	running: false
 	initing: false
+	server: null
 	callbacks: []
 	ensureRunning: (callback = (error) ->) ->
 		if @running
@@ -15,10 +17,17 @@ module.exports =
 		else
 			@initing = true
 			@callbacks.push callback
-			app.listen Settings.internal?.filestore?.port, "localhost", (error) => 
+			@server = app.listen Settings.internal?.filestore?.port, "localhost", (error) =>
 				throw error if error?
 				@running = true
 				logger.log("filestore running in dev mode")
 
 				for callback in @callbacks
 					callback()
+
+	stop: (callback = (error) ->) ->
+		logger.log("stopping")
+		@server.close (error) ->
+			logger.log("stopped")
+			Metrics.close()
+			callback(error)

--- a/test/acceptance/coffee/SendingFileTest.coffee
+++ b/test/acceptance/coffee/SendingFileTest.coffee
@@ -31,8 +31,9 @@ describe "Filestore", ->
 		FilestoreApp.ensureRunning done
 
 	after (done) ->
-		fs.unlinkSync @localFileReadPath
-		fs.rmdir @tmpDirectory, done
+		FilestoreApp.stop () =>
+			fs.unlinkSync @localFileReadPath
+			fs.rmdir @tmpDirectory, done
 
 	afterEach (done)->
 		fs.unlink @localFileWritePath, ->

--- a/test/acceptance/coffee/SendingFileTest.coffee
+++ b/test/acceptance/coffee/SendingFileTest.coffee
@@ -26,7 +26,7 @@ describe "Filestore", ->
 		@filestoreUrl = "http://localhost:#{settings.internal.filestore.port}"
 		FilestoreApp.ensureRunning done
 
-	beforeEach (done)->
+	afterEach (done)->
 		fs.unlink @localFileWritePath, ->
 			done()
 

--- a/test/acceptance/coffee/SendingFileTest.coffee
+++ b/test/acceptance/coffee/SendingFileTest.coffee
@@ -163,6 +163,11 @@ describe "Filestore", ->
 				beforeEach ->
 					@previewFileUrl = "#{@fileUrl}?style=preview"
 
+				afterEach (done) ->
+					postfix = "converted-cache_style-preview"
+					fs.unlink "#{userFiles}/#{@projectName}_#{@file_id}-#{postfix}", () ->
+						done()
+
 				it "should not time out", (done) ->
 					@timeout(1000 * 20)
 					request.get @previewFileUrl, (err, response, body) =>
@@ -177,21 +182,25 @@ describe "Filestore", ->
 						expect(body.length).to.be.greaterThan 400
 						done()
 
-			describe "warming the cache", ->
+				describe "warming the cache", ->
 
-				beforeEach ->
-					@fileUrl = @fileUrl + '?style=preview&cacheWarm=true'
+					beforeEach ->
+						@cacheCheckUrl = @fileUrl + '?style=preview&cacheWarm=true'
 
-				it "should not time out", (done) ->
-					@timeout(1000 * 20)
-					request.get @fileUrl, (err, response, body) =>
-						expect(response).to.not.equal null
-						done()
+					afterEach (done) ->
+						fs.unlink "#{uploads}/#{@projectName}-#{@file_id}.png", () ->
+							done()
 
-				it "should respond with only an 'OK'", (done) ->
-					# note: this test relies of the imagemagick conversion working
-					@timeout(1000 * 20)
-					request.get @fileUrl, (err, response, body) =>
-						expect(response.statusCode).to.equal 200
-						body.should.equal 'OK'
-						done()
+					it "should not time out", (done) ->
+						@timeout(1000 * 20)
+						request.get @cacheCheckUrl, (err, response, body) =>
+							expect(response).to.not.equal null
+							done()
+
+					it "should respond with only an 'OK'", (done) ->
+						# note: this test relies of the imagemagick conversion working
+						@timeout(1000 * 20)
+						request.get @cacheCheckUrl, (err, response, body) =>
+							expect(response.statusCode).to.equal 200
+							body.should.equal 'OK'
+							done()

--- a/test/acceptance/coffee/SendingFileTest.coffee
+++ b/test/acceptance/coffee/SendingFileTest.coffee
@@ -22,14 +22,13 @@ describe "Filestore", ->
 			"there are 3 lines in all"
 		].join("\n")
 
-		fs.writeFile(@localFileReadPath, @constantFileContent, done)
+		fs.writeFileSync @localFileReadPath, @constantFileContent
 		@filestoreUrl = "http://localhost:#{settings.internal.filestore.port}"
+		FilestoreApp.ensureRunning done
 
 	beforeEach (done)->
-		FilestoreApp.ensureRunning =>
-			fs.unlink @localFileWritePath, ->
-				done()
-
+		fs.unlink @localFileWritePath, ->
+			done()
 
 
 	it "should send a 200 for status endpoing", (done)->

--- a/test/acceptance/coffee/SendingFileTest.coffee
+++ b/test/acceptance/coffee/SendingFileTest.coffee
@@ -6,6 +6,8 @@ expect = chai.expect
 modulePath = "../../../app/js/LocalFileWriter.js"
 SandboxedModule = require('sandboxed-module')
 fs = require("fs")
+path = require("path")
+os = require("os")
 request = require("request")
 settings = require("settings-sharelatex")
 FilestoreApp = require "./FilestoreApp"
@@ -13,8 +15,10 @@ FilestoreApp = require "./FilestoreApp"
 describe "Filestore", ->
 
 	before (done)->
-		@localFileReadPath = "/tmp/filestore_acceptence_tests_file_read.txt"
-		@localFileWritePath = "/tmp/filestore_acceptence_tests_file_write.txt"
+		prefix = path.join os.tmpdir(), "filestore_acceptance_tests"
+		@tmpDirectory = fs.mkdtempSync prefix
+		@localFileReadPath = "#{@tmpDirectory}/file_read.txt"
+		@localFileWritePath = "#{@tmpDirectory}/file_write.txt"
 
 		@constantFileContent = [
 			"hello world"
@@ -25,6 +29,10 @@ describe "Filestore", ->
 		fs.writeFileSync @localFileReadPath, @constantFileContent
 		@filestoreUrl = "http://localhost:#{settings.internal.filestore.port}"
 		FilestoreApp.ensureRunning done
+
+	after (done) ->
+		fs.unlinkSync @localFileReadPath
+		fs.rmdir @tmpDirectory, done
 
 	afterEach (done)->
 		fs.unlink @localFileWritePath, ->


### PR DESCRIPTION
The acceptance tests leave plenty of files behind them.

Namely the test fixtures for reading / writing in `/tmp`, the files pushed during the setup of each test case in `user_files` and `uploads`, the copied project file in `user_files` and the preview images in the `user_files`.

The application is started but never stopped. `npm run` would kill the server, other (ide-)tools may leave it running without explicit configuration. This slows down local development as the app has to be killed manually after each test run.

This PR adds the cleanup of the mentioned files grouped per section and stops the application afterwards.

I suggest a diff view without white space changes, the diff in gh is too verbose.