### PR TITLE
Return file size on HEAD request

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -63,22 +63,23 @@ app.use (req, res, next) ->
 
 Metrics.injectMetricsRoute(app)
 
+app.head "/project/:project_id/file/:file_id", keyBuilder.userFileKey, fileController.getFileHead
 app.get  "/project/:project_id/file/:file_id", keyBuilder.userFileKey, fileController.getFile
 app.post "/project/:project_id/file/:file_id", keyBuilder.userFileKey, fileController.insertFile
+app.put  "/project/:project_id/file/:file_id", keyBuilder.userFileKey, bodyParser.json(), fileController.copyFile
+app.del  "/project/:project_id/file/:file_id", keyBuilder.userFileKey, fileController.deleteFile
 
-app.put "/project/:project_id/file/:file_id", keyBuilder.userFileKey, bodyParser.json(), fileController.copyFile
-app.del "/project/:project_id/file/:file_id", keyBuilder.userFileKey, fileController.deleteFile
-
+app.head "/template/:template_id/v/:version/:format", keyBuilder.templateFileKey, fileController.getFileHead
 app.get  "/template/:template_id/v/:version/:format", keyBuilder.templateFileKey, fileController.getFile
 app.get  "/template/:template_id/v/:version/:format/:sub_type", keyBuilder.templateFileKey, fileController.getFile
 app.post "/template/:template_id/v/:version/:format", keyBuilder.templateFileKey, fileController.insertFile
 
 
+app.head "/project/:project_id/public/:public_file_id", keyBuilder.publicFileKey, fileController.getFileHead
 app.get  "/project/:project_id/public/:public_file_id", keyBuilder.publicFileKey, fileController.getFile
 app.post "/project/:project_id/public/:public_file_id", keyBuilder.publicFileKey, fileController.insertFile
-
-app.put "/project/:project_id/public/:public_file_id", keyBuilder.publicFileKey, bodyParser.json(), fileController.copyFile
-app.del "/project/:project_id/public/:public_file_id", keyBuilder.publicFileKey, fileController.deleteFile
+app.put  "/project/:project_id/public/:public_file_id", keyBuilder.publicFileKey, bodyParser.json(), fileController.copyFile
+app.del  "/project/:project_id/public/:public_file_id", keyBuilder.publicFileKey, fileController.deleteFile
 
 app.get "/project/:project_id/size", keyBuilder.publicProjectKey, fileController.directorySize
 

--- a/app/coffee/FileHandler.coffee
+++ b/app/coffee/FileHandler.coffee
@@ -31,6 +31,9 @@ module.exports = FileHandler =
 		else
 			@_getConvertedFile bucket, key, opts, callback
 
+	getFileSize: (bucket, key, callback) ->
+		PersistorManager.getFileSize(bucket, key, callback)
+
 	_getStandardFile: (bucket, key, opts, callback)->
 		PersistorManager.getFileStream bucket, key, opts, (err, fileStream)->
 			if err? and !(err instanceof Errors.NotFoundError)

--- a/test/acceptance/coffee/SendingFileTest.coffee
+++ b/test/acceptance/coffee/SendingFileTest.coffee
@@ -32,7 +32,7 @@ describe "Filestore", ->
 
 
 
-	it "should send a 200 for status endpoing", (done)->
+	it "should send a 200 for status endpoint", (done)->
 		request "#{@filestoreUrl}/status", (err, response, body)->
 			response.statusCode.should.equal 200
 			body.indexOf("filestore").should.not.equal -1
@@ -57,6 +57,13 @@ describe "Filestore", ->
 				uri: @fileUrl + '___this_is_clearly_wrong___'
 			request.get options, (err, response, body) =>
 				response.statusCode.should.equal 404
+				done()
+
+		it "should return the file size on a HEAD request", (done) ->
+			expectedLength = Buffer.byteLength(@constantFileContent)
+			request.head @fileUrl, (err, res) =>
+				expect(res.statusCode).to.equal(200)
+				expect(res.headers['content-length']).to.equal(expectedLength.toString())
 				done()
 
 		it "should be able get the file back", (done)->

--- a/test/unit/coffee/FileHandlerTests.coffee
+++ b/test/unit/coffee/FileHandlerTests.coffee
@@ -108,7 +108,6 @@ describe "FileHandler", ->
 				@handler._getConvertedFile.called.should.equal true
 				done()
 
-
 	describe "_getStandardFile", ->
 
 		beforeEach ->


### PR DESCRIPTION
### Description

This will be used by the file preview feature when it gets partial content.

#### Related Issues / PRs

* overleaf/issues#1885

### Review

I deliberately used the AWS SDK directly instead of the [knox library](https://github.com/Automattic/knox). This library looks unmaintained (54 open issues, last issue closed in 2015, last commit in 2016).

#### Potential Impact

Anything that makes HEAD requests on the filestore service will see an additional Content-Length header and might get confused. This is very unlikely, though.

Filestore serves 3 kinds of files: user files, templates and public files. User files can be tested by uploading a file to a project. I'm not sure how to test the two other kinds.

#### Manual Testing Performed

- [ ] Make a HEAD request to user file (/project/:project_id/file/:file_id)
- [ ] Upload a text file to a project and preview it
