### PR TITLE
Fix createUnbufferedStream() function call

### DIFF
--- a/app/coffee/S3PersistorManager.coffee
+++ b/app/coffee/S3PersistorManager.coffee
@@ -102,7 +102,7 @@ module.exports =
 			if statusCode not in [200, 206]
 				logger.log({bucketName: bucketName, key: key }, "error getting file from s3: #{statusCode}")
 				return callback(new Error("Got non-200 response from S3: #{statusCode} #{statusMessage}"), null)
-			stream = response.httpResponse.getUnbufferedStream()
+			stream = response.httpResponse.createUnbufferedStream()
 			callback(null, stream)
 
 		request.on 'error', (err) =>

--- a/test/unit/coffee/S3PersistorManagerTests.coffee
+++ b/test/unit/coffee/S3PersistorManagerTests.coffee
@@ -32,7 +32,7 @@ describe "S3PersistorManagerTests", ->
 			send: sinon.stub()
 		@s3Response =
 			httpResponse:
-				getUnbufferedStream: sinon.stub()
+				createUnbufferedStream: sinon.stub()
 		@s3Client =
 			copyObject: sinon.stub()
 			headObject: sinon.stub()
@@ -64,7 +64,7 @@ describe "S3PersistorManagerTests", ->
 				@expectedStream = { expectedStream: true }
 				@s3Request.send.callsFake () =>
 					@s3EventHandlers.httpHeaders(200, {}, @s3Response, "OK")
-				@s3Response.httpResponse.getUnbufferedStream.returns(@expectedStream)
+				@s3Response.httpResponse.createUnbufferedStream.returns(@expectedStream)
 
 			it "returns a stream", (done) ->
 				@S3PersistorManager.getFileStream @bucketName, @key, {}, (err, stream) =>


### PR DESCRIPTION
### Description

In 49a21155f642670dfea264ac73fb60241f37cb87, I managed to incorrectly
write the `createUnbufferedStream()` function from the AWS SDK as
`getUnbufferedStream()` and to consistently use that naming in the unit
tests.

This commit fixes that. I have tested again on S3.

#### Related Issues / PRs

Cause: https://github.com/overleaf/filestore/pull/53

### Review

#### Manual Testing Performed

- [ ] Upload a file in a project and preview it
- [ ] Get a file directly from Filestore
- [ ] Try to get a non-existent file from Filestore and expect a 404