### PR TITLE
Add metrics for S3 ingress and egress, and improve acceptance tests

### DIFF
--- a/app/coffee/S3PersistorManager.coffee
+++ b/app/coffee/S3PersistorManager.coffee
@@ -132,6 +132,9 @@ module.exports =
 				logger.log({bucketName: bucketName, key: key }, "error getting file from s3: #{statusCode}")
 				return callback(new Error("Got non-200 response from S3: #{statusCode} #{statusMessage}"), null)
 			stream = response.httpResponse.createUnbufferedStream()
+			stream.on 'data', (data) ->
+				metrics.count 's3.ingress', data.byteLength
+
 			callback(null, stream)
 
 		s3Request.on 'error', (err) =>

--- a/app/coffee/S3PersistorManager.coffee
+++ b/app/coffee/S3PersistorManager.coffee
@@ -43,8 +43,9 @@ getS3Options = (credentials) ->
 			secretAccessKey: credentials.auth_secret
 
 	if settings.filestore.s3.endpoint
+		endpoint = URL.parse(settings.filestore.s3.endpoint)
 		options.endpoint = settings.filestore.s3.endpoint
-		options.sslEnabled = false
+		options.sslEnabled = endpoint.protocol == 'https'
 
 	return options
 

--- a/app/coffee/S3PersistorManager.coffee
+++ b/app/coffee/S3PersistorManager.coffee
@@ -95,9 +95,9 @@ module.exports =
 		}
 		if opts.start? and opts.end?
 			s3Params['Range'] = "bytes=#{opts.start}-#{opts.end}"
-		request = s3.getObject(s3Params)
+		s3Request = s3.getObject(s3Params)
 
-		request.on 'httpHeaders', (statusCode, headers, response, statusMessage) =>
+		s3Request.on 'httpHeaders', (statusCode, headers, response, statusMessage) =>
 			if statusCode in [403, 404]
 				# S3 returns a 403 instead of a 404 when the user doesn't have
 				# permission to list the bucket contents.
@@ -109,11 +109,11 @@ module.exports =
 			stream = response.httpResponse.createUnbufferedStream()
 			callback(null, stream)
 
-		request.on 'error', (err) =>
+		s3Request.on 'error', (err) =>
 			logger.err({ err: err, bucketName: bucketName, key: key }, "error getting file stream from s3")
 			callback(err)
 
-		request.send()
+		s3Request.send()
 
 	getFileSize: (bucketName, key, callback) ->
 		logger.log({ bucketName: bucketName, key: key }, "getting file size from S3")

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -16,6 +16,7 @@ settings =
 			s3:
 				key: process.env['AWS_KEY']
 				secret: process.env['AWS_SECRET']
+				endpoint: process.env['AWS_S3_ENDPOINT']
 			stores:
 				user_files: process.env['AWS_S3_USER_FILES_BUCKET_NAME']
 				template_files: process.env['AWS_S3_TEMPLATE_FILES_BUCKET_NAME']

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -57,4 +57,6 @@ services:
 
   fakes3:
     image: adobe/s3mock
-    command: --initialBuckets=fake_user_files,fake_template_files,fake_public_files
+    environment:
+      - initialBuckets=fake_user_files,fake_template_files,fake_public_files
+

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -3,7 +3,7 @@
 # https://github.com/sharelatex/sharelatex-dev-environment
 # Version: 1.1.24
 
-version: "2"
+version: "2.1"
 
 services:
   test_unit:
@@ -33,9 +33,12 @@ services:
       AWS_S3_PUBLIC_FILES_BUCKET_NAME: fake_public_files
       AWS_S3_ENDPOINT: http://fakes3:9090
     depends_on:
-      - mongo
-      - redis
-      - fakes3
+      mongo:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      fakes3:
+        condition: service_healthy
     user: node
     command: npm run test:acceptance:_run
 
@@ -59,4 +62,6 @@ services:
     image: adobe/s3mock
     environment:
       - initialBuckets=fake_user_files,fake_template_files,fake_public_files
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9090"]
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -25,6 +25,7 @@ services:
       ENABLE_CONVERSIONS: "true"
       MOCHA_GREP: ${MOCHA_GREP}
       NODE_ENV: test
+      USE_PROM_METRICS: "true"
       AWS_KEY: fake
       AWS_SECRET: fake
       AWS_S3_USER_FILES_BUCKET_NAME: fake_user_files

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -25,9 +25,16 @@ services:
       ENABLE_CONVERSIONS: "true"
       MOCHA_GREP: ${MOCHA_GREP}
       NODE_ENV: test
+      AWS_KEY: fake
+      AWS_SECRET: fake
+      AWS_S3_USER_FILES_BUCKET_NAME: fake_user_files
+      AWS_S3_TEMPLATE_FILES_BUCKET_NAME: fake_template_files
+      AWS_S3_PUBLIC_FILES_BUCKET_NAME: fake_public_files
+      AWS_S3_ENDPOINT: http://fakes3:9090
     depends_on:
       - mongo
       - redis
+      - fakes3
     user: node
     command: npm run test:acceptance:_run
 
@@ -46,3 +53,7 @@ services:
 
   mongo:
     image: mongo:3.4
+
+  fakes3:
+    image: adobe/s3mock
+    command: --initialBuckets=fake_user_files,fake_template_files,fake_public_files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 # https://github.com/sharelatex/sharelatex-dev-environment
 # Version: 1.1.24
 
-version: "2"
+version: "2.1"
 
 services:
   test_unit:
@@ -40,9 +40,12 @@ services:
       AWS_S3_ENDPOINT: http://fakes3:9090
     user: node
     depends_on:
-      - mongo
-      - redis
-      - fakes3
+      mongo:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      fakes3:
+        condition: service_healthy
     command: npm run test:acceptance
 
 
@@ -65,5 +68,7 @@ services:
     image: adobe/s3mock
     environment:
       - initialBuckets=fake_user_files,fake_template_files,fake_public_files
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9090"]
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       ENABLE_CONVERSIONS: "true"
       LOG_LEVEL: ERROR
       NODE_ENV: test
+      USE_PROM_METRICS: "true"
       AWS_KEY: fake
       AWS_SECRET: fake
       AWS_S3_USER_FILES_BUCKET_NAME: fake_user_files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,10 +31,17 @@ services:
       ENABLE_CONVERSIONS: "true"
       LOG_LEVEL: ERROR
       NODE_ENV: test
+      AWS_KEY: fake
+      AWS_SECRET: fake
+      AWS_S3_USER_FILES_BUCKET_NAME: fake_user_files
+      AWS_S3_TEMPLATE_FILES_BUCKET_NAME: fake_template_files
+      AWS_S3_PUBLIC_FILES_BUCKET_NAME: fake_public_files
+      AWS_S3_ENDPOINT: http://fakes3:9090
     user: node
     depends_on:
       - mongo
       - redis
+      - fakes3
     command: npm run test:acceptance
 
 
@@ -52,5 +59,10 @@ services:
 
   mongo:
     image: mongo:3.4
+
+  fakes3:
+    image: adobe/s3mock
+    environment:
+      - initialBuckets=fake_user_files,fake_template_files,fake_public_files
 
 

--- a/test/acceptance/coffee/FilestoreApp.coffee
+++ b/test/acceptance/coffee/FilestoreApp.coffee
@@ -2,6 +2,9 @@ app = require('../../../app')
 require("logger-sharelatex").logger.level("info")
 logger = require("logger-sharelatex")
 Settings = require("settings-sharelatex")
+request = require('request')
+
+S3_TRIES = 30
 
 module.exports =
 	running: false
@@ -22,3 +25,21 @@ module.exports =
 
 				for callback in @callbacks
 					callback()
+
+	waitForS3: (callback, tries) ->
+		return callback() unless Settings.filestore.s3?.endpoint
+		tries = 1 unless tries
+
+		request.get "#{Settings.filestore.s3.endpoint}/", (err, response) =>
+			console.log(err, response?.statusCode, tries)
+			if !err && [200, 404].includes(response?.statusCode)
+				return callback()
+
+			if tries == S3_TRIES
+				return callback('timed out waiting for S3')
+
+			setTimeout(
+				() =>
+					@waitForS3 callback, tries + 1
+				1000
+			)

--- a/test/acceptance/coffee/SendingFileTest.coffee
+++ b/test/acceptance/coffee/SendingFileTest.coffee
@@ -29,8 +29,10 @@ describe "Filestore", ->
 			"there are 3 lines in all"
 		].join("\n")
 
-		fs.writeFile(@localFileReadPath, @constantFileContent, done)
 		@filestoreUrl = "http://localhost:#{settings.internal.filestore.port}"
+		fs.writeFile @localFileReadPath, @constantFileContent, (err) ->
+			return done(err) if err
+			FilestoreApp.waitForS3(done)
 
 	beforeEach (done)->
 		FilestoreApp.ensureRunning =>

--- a/test/unit/coffee/S3PersistorManagerTests.coffee
+++ b/test/unit/coffee/S3PersistorManagerTests.coffee
@@ -62,6 +62,7 @@ describe "S3PersistorManagerTests", ->
 		describe "success", ->
 			beforeEach () ->
 				@expectedStream = { expectedStream: true }
+				@expectedStream.on = sinon.stub()
 				@s3Request.send.callsFake () =>
 					@s3EventHandlers.httpHeaders(200, {}, @s3Response, "OK")
 				@s3Response.httpResponse.createUnbufferedStream.returns(@expectedStream)


### PR DESCRIPTION
### Description

Primarily, this adds `s3.ingress` and `s3.egress` metrics to Filestore.

In order to test this, I wanted to write an acceptance test that verifies the metric. This involved:
* Adding a fake S3 container to the docker test environment
* Configuring the test environment to use S3 instead of the filesystem
* Setting `USE_PROM_METRICS` so that we can scrape the `/metrics` endpoint

### Review

Removed the unused `AWSSDKPersistorManager`. It's confusing having two AWS persistors.

Renamed a local `request` variable to `s3request`. The former was overwriting the global `request` object in a way that broke other methods in the file. This only became apparent when S3 was being used for the accpetance tests. Specifically, the methods were `deleteFile` and `checkIfFileExists`. I don't think we have anything currently running in production that does this.

#### Manual Testing Performed

- [ ] Upload a file, check metrics
- [ ] Download a file, check metrics
