### PR TITLE
Decaf cleanup for FileHandler and LocalFileWriter

### DIFF
--- a/app/js/Errors.js
+++ b/app/js/Errors.js
@@ -18,7 +18,10 @@ class BackwardCompatibleError extends OError {
 }
 
 class NotFoundError extends BackwardCompatibleError {}
+class WriteError extends BackwardCompatibleError {}
+class ReadError extends BackwardCompatibleError {}
 class ConversionsDisabledError extends BackwardCompatibleError {}
+class ConversionError extends BackwardCompatibleError {}
 
 class FailedCommandError extends OError {
   constructor(command, code, stdout, stderr) {
@@ -35,4 +38,11 @@ class FailedCommandError extends OError {
   }
 }
 
-module.exports = { NotFoundError, FailedCommandError, ConversionsDisabledError }
+module.exports = {
+  NotFoundError,
+  FailedCommandError,
+  ConversionsDisabledError,
+  WriteError,
+  ReadError,
+  ConversionError
+}

--- a/app/js/LocalFileWriter.js
+++ b/app/js/LocalFileWriter.js
@@ -1,91 +1,57 @@
-/* eslint-disable
-    handle-callback-err,
-*/
-// TODO: This file was created by bulk-decaffeinate.
-// Fix any style issues and re-enable lint.
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * DS207: Consider shorter variations of null checks
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 const fs = require('fs')
 const uuid = require('node-uuid')
 const path = require('path')
-const _ = require('underscore')
+const Stream = require('stream')
+const { callbackify, promisify } = require('util')
 const logger = require('logger-sharelatex')
 const metrics = require('metrics-sharelatex')
 const Settings = require('settings-sharelatex')
-const Errors = require('./Errors')
+const { WriteError } = require('./Errors')
 
 module.exports = {
-  writeStream(stream, key, callback) {
-    const timer = new metrics.Timer('writingFile')
-    callback = _.once(callback)
-    const fsPath = this._getPath(key)
-    logger.log({ fsPath }, 'writing file locally')
-    const writeStream = fs.createWriteStream(fsPath)
-    writeStream.on('finish', function() {
-      timer.done()
-      logger.log({ fsPath }, 'finished writing file locally')
-      return callback(null, fsPath)
-    })
-    writeStream.on('error', function(err) {
-      logger.err(
-        { err, fsPath },
-        'problem writing file locally, with write stream'
-      )
-      return callback(err)
-    })
-    stream.on('error', function(err) {
-      logger.log(
-        { err, fsPath },
-        'problem writing file locally, with read stream'
-      )
-      return callback(err)
-    })
-    return stream.pipe(writeStream)
+  promises: {
+    writeStream,
+    deleteFile
   },
+  writeStream: callbackify(writeStream),
+  deleteFile: callbackify(deleteFile)
+}
 
-  getStream(fsPath, _callback) {
-    if (_callback == null) {
-      _callback = function(err, res) {}
-    }
-    const callback = _.once(_callback)
-    const timer = new metrics.Timer('readingFile')
-    logger.log({ fsPath }, 'reading file locally')
-    const readStream = fs.createReadStream(fsPath)
-    readStream.on('end', function() {
-      timer.done()
-      return logger.log({ fsPath }, 'finished reading file locally')
-    })
-    readStream.on('error', function(err) {
-      logger.err(
-        { err, fsPath },
-        'problem reading file locally, with read stream'
-      )
-      if (err.code === 'ENOENT') {
-        return callback(new Errors.NotFoundError(err.message), null)
-      } else {
-        return callback(err)
-      }
-    })
-    return callback(null, readStream)
-  },
+const pipeline = promisify(Stream.pipeline)
 
-  deleteFile(fsPath, callback) {
-    if (fsPath == null || fsPath === '') {
-      return callback()
-    }
-    logger.log({ fsPath }, 'removing local temp file')
-    return fs.unlink(fsPath, callback)
-  },
+async function writeStream(stream, key) {
+  const timer = new metrics.Timer('writingFile')
+  const fsPath = _getPath(key)
 
-  _getPath(key) {
-    if (key == null) {
-      key = uuid.v1()
-    }
-    key = key.replace(/\//g, '-')
-    return path.join(Settings.path.uploadFolder, key)
+  logger.log({ fsPath }, 'writing file locally')
+
+  const writeStream = fs.createWriteStream(fsPath)
+  try {
+    await pipeline(stream, writeStream)
+    timer.done()
+    logger.log({ fsPath }, 'finished writing file locally')
+    return fsPath
+  } catch (err) {
+    logger.err({ err, fsPath }, 'problem writing file locally')
+    throw new WriteError({
+      message: 'problem writing file locally',
+      info: { err, fsPath }
+    }).withCause(err)
   }
+}
+
+async function deleteFile(fsPath) {
+  if (!fsPath) {
+    return
+  }
+  logger.log({ fsPath }, 'removing local temp file')
+  await promisify(fs.unlink)(fsPath)
+}
+
+function _getPath(key) {
+  if (key == null) {
+    key = uuid.v1()
+  }
+  key = key.replace(/\//g, '-')
+  return path.join(Settings.path.uploadFolder, key)
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4763,6 +4763,12 @@
         "type-detect": "^4.0.8"
       }
     },
+    "sinon-chai": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.3.0.tgz",
+      "integrity": "sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==",
+      "dev": true
+    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "prettier-eslint": "^9.0.1",
     "prettier-eslint-cli": "^5.0.0",
     "sandboxed-module": "2.0.3",
-    "sinon": "7.1.1"
+    "sinon": "7.1.1",
+    "sinon-chai": "^3.3.0"
   }
 }

--- a/test/unit/js/FileHandlerTests.js
+++ b/test/unit/js/FileHandlerTests.js
@@ -1,367 +1,233 @@
-/* eslint-disable
-    handle-callback-err,
-    no-return-assign,
-    no-unused-vars,
-*/
-// TODO: This file was created by bulk-decaffeinate.
-// Fix any style issues and re-enable lint.
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
-const { assert } = require('chai')
 const sinon = require('sinon')
 const chai = require('chai')
-const should = chai.should()
 const { expect } = chai
 const modulePath = '../../../app/js/FileHandler.js'
 const SandboxedModule = require('sandboxed-module')
 
 describe('FileHandler', function() {
-  beforeEach(function() {
-    this.settings = {
-      s3: {
-        buckets: {
-          user_files: 'user_files'
-        }
+  let PersistorManager,
+    LocalFileWriter,
+    FileConverter,
+    KeyBuilder,
+    ImageOptimiser,
+    FileHandler,
+    fs
+  const settings = {
+    s3: {
+      buckets: {
+        user_files: 'user_files'
       }
     }
-    this.PersistorManager = {
-      getFileStream: sinon.stub(),
-      checkIfFileExists: sinon.stub(),
-      deleteFile: sinon.stub(),
-      deleteDirectory: sinon.stub(),
-      sendStream: sinon.stub(),
-      insertFile: sinon.stub(),
-      directorySize: sinon.stub()
+  }
+
+  const bucket = 'my_bucket'
+  const key = 'key/here'
+  const convertedFolderKey = 'convertedFolder'
+  const sourceStream = 'sourceStream'
+  const convertedKey = 'convertedKey'
+  const readStream = {
+    stream: 'readStream',
+    on: sinon.stub()
+  }
+
+  beforeEach(function() {
+    PersistorManager = {
+      getFileStream: sinon.stub().yields(null, sourceStream),
+      checkIfFileExists: sinon.stub().yields(),
+      deleteFile: sinon.stub().yields(),
+      deleteDirectory: sinon.stub().yields(),
+      sendStream: sinon.stub().yields(),
+      insertFile: sinon.stub().yields(),
+      sendFile: sinon.stub().yields(),
+      directorySize: sinon.stub().yields()
     }
-    this.LocalFileWriter = {
-      writeStream: sinon.stub(),
-      getStream: sinon.stub(),
-      deleteFile: sinon.stub()
+    LocalFileWriter = {
+      writeStream: sinon.stub().yields(),
+      deleteFile: sinon.stub().yields()
     }
-    this.FileConverter = {
-      convert: sinon.stub(),
-      thumbnail: sinon.stub(),
-      preview: sinon.stub()
+    FileConverter = {
+      convert: sinon.stub().yields(),
+      thumbnail: sinon.stub().yields(),
+      preview: sinon.stub().yields()
     }
-    this.keyBuilder = {
-      addCachingToKey: sinon.stub(),
-      getConvertedFolderKey: sinon.stub()
+    KeyBuilder = {
+      addCachingToKey: sinon.stub().returns(convertedKey),
+      getConvertedFolderKey: sinon.stub().returns(convertedFolderKey)
     }
-    this.ImageOptimiser = { compressPng: sinon.stub() }
-    this.handler = SandboxedModule.require(modulePath, {
+    ImageOptimiser = { compressPng: sinon.stub().yields() }
+    fs = {
+      createReadStream: sinon.stub().returns(readStream)
+    }
+
+    FileHandler = SandboxedModule.require(modulePath, {
       requires: {
-        'settings-sharelatex': this.settings,
-        './PersistorManager': this.PersistorManager,
-        './LocalFileWriter': this.LocalFileWriter,
-        './FileConverter': this.FileConverter,
-        './KeyBuilder': this.keyBuilder,
-        './ImageOptimiser': this.ImageOptimiser,
+        'settings-sharelatex': settings,
+        './PersistorManager': PersistorManager,
+        './LocalFileWriter': LocalFileWriter,
+        './FileConverter': FileConverter,
+        './KeyBuilder': KeyBuilder,
+        './ImageOptimiser': ImageOptimiser,
+        fs: fs,
         'logger-sharelatex': {
           log() {},
           err() {}
         }
-      }
+      },
+      globals: { console }
     })
-    this.bucket = 'my_bucket'
-    this.key = 'key/here'
-    this.stubbedPath = '/var/somewhere/path'
-    this.format = 'png'
-    return (this.formattedStubbedPath = `${this.stubbedPath}.${this.format}`)
   })
 
   describe('insertFile', function() {
-    beforeEach(function() {
-      this.stream = {}
-      this.PersistorManager.deleteDirectory.callsArgWith(2)
-      return this.PersistorManager.sendStream.callsArgWith(3)
-    })
+    const stream = 'stream'
 
     it('should send file to the filestore', function(done) {
-      return this.handler.insertFile(this.bucket, this.key, this.stream, () => {
-        this.PersistorManager.sendStream
-          .calledWith(this.bucket, this.key, this.stream)
-          .should.equal(true)
-        return done()
+      FileHandler.insertFile(bucket, key, stream, err => {
+        expect(err).not.to.exist
+        expect(PersistorManager.sendStream).to.have.been.calledWith(
+          bucket,
+          key,
+          stream
+        )
+        done()
       })
     })
 
-    return it('should delete the convetedKey folder', function(done) {
-      this.keyBuilder.getConvertedFolderKey.returns(this.stubbedConvetedKey)
-      return this.handler.insertFile(this.bucket, this.key, this.stream, () => {
-        this.PersistorManager.deleteDirectory
-          .calledWith(this.bucket, this.stubbedConvetedKey)
-          .should.equal(true)
-        return done()
+    it('should delete the convertedKey folder', function(done) {
+      FileHandler.insertFile(bucket, key, stream, err => {
+        expect(err).not.to.exist
+        expect(PersistorManager.deleteDirectory).to.have.been.calledWith(
+          bucket,
+          convertedFolderKey
+        )
+        done()
       })
     })
   })
 
   describe('deleteFile', function() {
-    beforeEach(function() {
-      this.keyBuilder.getConvertedFolderKey.returns(this.stubbedConvetedKey)
-      this.PersistorManager.deleteFile.callsArgWith(2)
-      return this.PersistorManager.deleteDirectory.callsArgWith(2)
-    })
-
     it('should tell the filestore manager to delete the file', function(done) {
-      return this.handler.deleteFile(this.bucket, this.key, () => {
-        this.PersistorManager.deleteFile
-          .calledWith(this.bucket, this.key)
-          .should.equal(true)
-        return done()
+      FileHandler.deleteFile(bucket, key, err => {
+        expect(err).not.to.exist
+        expect(PersistorManager.deleteFile).to.have.been.calledWith(bucket, key)
+        done()
       })
     })
 
-    return it('should tell the filestore manager to delete the cached foler', function(done) {
-      return this.handler.deleteFile(this.bucket, this.key, () => {
-        this.PersistorManager.deleteDirectory
-          .calledWith(this.bucket, this.stubbedConvetedKey)
-          .should.equal(true)
-        return done()
+    it('should tell the filestore manager to delete the cached folder', function(done) {
+      FileHandler.deleteFile(bucket, key, err => {
+        expect(err).not.to.exist
+        expect(PersistorManager.deleteDirectory).to.have.been.calledWith(
+          bucket,
+          convertedFolderKey
+        )
+        done()
       })
     })
   })
 
   describe('getFile', function() {
-    beforeEach(function() {
-      this.handler._getStandardFile = sinon.stub().callsArgWith(3)
-      return (this.handler._getConvertedFile = sinon.stub().callsArgWith(3))
-    })
-
-    it('should call _getStandardFile if no format or style are defined', function(done) {
-      return this.handler.getFile(this.bucket, this.key, null, () => {
-        this.handler._getStandardFile.called.should.equal(true)
-        this.handler._getConvertedFile.called.should.equal(false)
-        return done()
+    it('should return the source stream no format or style are defined', function(done) {
+      FileHandler.getFile(bucket, key, null, (err, stream) => {
+        expect(err).not.to.exist
+        expect(stream).to.equal(sourceStream)
+        done()
       })
     })
 
-    it('should pass options to _getStandardFile', function(done) {
+    it('should pass options through to PersistorManager', function(done) {
       const options = { start: 0, end: 8 }
-      return this.handler.getFile(this.bucket, this.key, options, () => {
-        expect(this.handler._getStandardFile.lastCall.args[2].start).to.equal(0)
-        expect(this.handler._getStandardFile.lastCall.args[2].end).to.equal(8)
-        return done()
+      FileHandler.getFile(bucket, key, options, err => {
+        expect(err).not.to.exist
+        expect(PersistorManager.getFileStream).to.have.been.calledWith(
+          bucket,
+          key,
+          options
+        )
+        done()
       })
     })
 
-    return it('should call _getConvertedFile if a format is defined', function(done) {
-      return this.handler.getFile(
-        this.bucket,
-        this.key,
-        { format: 'png' },
-        () => {
-          this.handler._getStandardFile.called.should.equal(false)
-          this.handler._getConvertedFile.called.should.equal(true)
-          return done()
-        }
-      )
-    })
-  })
+    describe('when a format is defined', function() {
+      let result
 
-  describe('_getStandardFile', function() {
-    beforeEach(function() {
-      this.fileStream = { on() {} }
-      return this.PersistorManager.getFileStream.callsArgWith(
-        3,
-        'err',
-        this.fileStream
-      )
-    })
+      describe('when the file is not cached', function() {
+        beforeEach(function(done) {
+          FileHandler.getFile(bucket, key, { format: 'png' }, (err, stream) => {
+            result = { err, stream }
+            done()
+          })
+        })
 
-    it('should get the stream', function(done) {
-      return this.handler.getFile(this.bucket, this.key, null, () => {
-        this.PersistorManager.getFileStream
-          .calledWith(this.bucket, this.key)
-          .should.equal(true)
-        return done()
+        it('should convert the file', function() {
+          expect(FileConverter.convert).to.have.been.called
+          expect(ImageOptimiser.compressPng).to.have.been.called
+        })
+
+        it('should return the the converted stream', function() {
+          expect(result.err).not.to.exist
+          expect(result.stream).to.equal(readStream)
+          expect(PersistorManager.getFileStream).to.have.been.calledWith(
+            bucket,
+            key
+          )
+        })
+      })
+
+      describe('when the file is cached', function() {
+        beforeEach(function(done) {
+          PersistorManager.checkIfFileExists = sinon.stub().yields(null, true)
+          FileHandler.getFile(bucket, key, { format: 'png' }, (err, stream) => {
+            result = { err, stream }
+            done()
+          })
+        })
+
+        it('should not convert the file', function() {
+          expect(FileConverter.convert).not.to.have.been.called
+          expect(ImageOptimiser.compressPng).not.to.have.been.called
+        })
+
+        it('should return the cached stream', function() {
+          expect(result.err).not.to.exist
+          expect(result.stream).to.equal(sourceStream)
+          expect(PersistorManager.getFileStream).to.have.been.calledWith(
+            bucket,
+            convertedKey
+          )
+        })
       })
     })
 
-    it('should return the stream and error', function(done) {
-      return this.handler.getFile(
-        this.bucket,
-        this.key,
-        null,
-        (err, stream) => {
-          err.should.equal('err')
-          stream.should.equal(this.fileStream)
-          return done()
-        }
-      )
-    })
-
-    return it('should pass options to PersistorManager', function(done) {
-      return this.handler.getFile(
-        this.bucket,
-        this.key,
-        { start: 0, end: 8 },
-        () => {
-          expect(
-            this.PersistorManager.getFileStream.lastCall.args[2].start
-          ).to.equal(0)
-          expect(
-            this.PersistorManager.getFileStream.lastCall.args[2].end
-          ).to.equal(8)
-          return done()
-        }
-      )
-    })
-  })
-
-  describe('_getConvertedFile', function() {
-    it('should getFileStream if it does exists', function(done) {
-      this.PersistorManager.checkIfFileExists.callsArgWith(2, null, true)
-      this.PersistorManager.getFileStream.callsArgWith(3)
-      return this.handler._getConvertedFile(this.bucket, this.key, {}, () => {
-        this.PersistorManager.getFileStream
-          .calledWith(this.bucket)
-          .should.equal(true)
-        return done()
+    describe('when a style is defined', function() {
+      it('generates a thumbnail when requested', function(done) {
+        FileHandler.getFile(bucket, key, { style: 'thumbnail' }, err => {
+          expect(err).not.to.exist
+          expect(FileConverter.thumbnail).to.have.been.called
+          expect(FileConverter.preview).not.to.have.been.called
+          done()
+        })
       })
-    })
 
-    return it('should call _getConvertedFileAndCache if it does exists', function(done) {
-      this.PersistorManager.checkIfFileExists.callsArgWith(2, null, false)
-      this.handler._getConvertedFileAndCache = sinon.stub().callsArgWith(4)
-      return this.handler._getConvertedFile(this.bucket, this.key, {}, () => {
-        this.handler._getConvertedFileAndCache
-          .calledWith(this.bucket, this.key)
-          .should.equal(true)
-        return done()
+      it('generates a preview when requested', function(done) {
+        FileHandler.getFile(bucket, key, { style: 'preview' }, err => {
+          expect(err).not.to.exist
+          expect(FileConverter.thumbnail).not.to.have.been.called
+          expect(FileConverter.preview).to.have.been.called
+          done()
+        })
       })
     })
   })
 
-  describe('_getConvertedFileAndCache', () =>
-    it('should _convertFile ', function(done) {
-      this.stubbedStream = { something: 'here' }
-      this.localStream = {
-        on() {}
-      }
-      this.PersistorManager.sendFile = sinon.stub().callsArgWith(3)
-      this.LocalFileWriter.getStream = sinon
-        .stub()
-        .callsArgWith(1, null, this.localStream)
-      this.convetedKey = this.key + 'converted'
-      this.handler._convertFile = sinon
-        .stub()
-        .callsArgWith(3, null, this.stubbedPath)
-      this.ImageOptimiser.compressPng = sinon.stub().callsArgWith(1)
-      return this.handler._getConvertedFileAndCache(
-        this.bucket,
-        this.key,
-        this.convetedKey,
-        {},
-        (err, fsStream) => {
-          this.handler._convertFile.called.should.equal(true)
-          this.PersistorManager.sendFile
-            .calledWith(this.bucket, this.convetedKey, this.stubbedPath)
-            .should.equal(true)
-          this.ImageOptimiser.compressPng
-            .calledWith(this.stubbedPath)
-            .should.equal(true)
-          this.LocalFileWriter.getStream
-            .calledWith(this.stubbedPath)
-            .should.equal(true)
-          fsStream.should.equal(this.localStream)
-          return done()
-        }
-      )
-    }))
-
-  describe('_convertFile', function() {
-    beforeEach(function() {
-      this.FileConverter.convert.callsArgWith(
-        2,
-        null,
-        this.formattedStubbedPath
-      )
-      this.FileConverter.thumbnail.callsArgWith(
-        1,
-        null,
-        this.formattedStubbedPath
-      )
-      this.FileConverter.preview.callsArgWith(
-        1,
-        null,
-        this.formattedStubbedPath
-      )
-      this.handler._writeS3FileToDisk = sinon
-        .stub()
-        .callsArgWith(3, null, this.stubbedPath)
-      return this.LocalFileWriter.deleteFile.callsArgWith(1)
-    })
-
-    it('should call thumbnail on the writer path if style was thumbnail was specified', function(done) {
-      return this.handler._convertFile(
-        this.bucket,
-        this.key,
-        { style: 'thumbnail' },
-        (err, path) => {
-          path.should.equal(this.formattedStubbedPath)
-          this.FileConverter.thumbnail
-            .calledWith(this.stubbedPath)
-            .should.equal(true)
-          this.LocalFileWriter.deleteFile
-            .calledWith(this.stubbedPath)
-            .should.equal(true)
-          return done()
-        }
-      )
-    })
-
-    it('should call preview on the writer path if style was preview was specified', function(done) {
-      return this.handler._convertFile(
-        this.bucket,
-        this.key,
-        { style: 'preview' },
-        (err, path) => {
-          path.should.equal(this.formattedStubbedPath)
-          this.FileConverter.preview
-            .calledWith(this.stubbedPath)
-            .should.equal(true)
-          this.LocalFileWriter.deleteFile
-            .calledWith(this.stubbedPath)
-            .should.equal(true)
-          return done()
-        }
-      )
-    })
-
-    return it('should call convert on the writer path if a format was specified', function(done) {
-      return this.handler._convertFile(
-        this.bucket,
-        this.key,
-        { format: this.format },
-        (err, path) => {
-          path.should.equal(this.formattedStubbedPath)
-          this.FileConverter.convert
-            .calledWith(this.stubbedPath, this.format)
-            .should.equal(true)
-          this.LocalFileWriter.deleteFile
-            .calledWith(this.stubbedPath)
-            .should.equal(true)
-          return done()
-        }
-      )
-    })
-  })
-
-  return describe('getDirectorySize', function() {
-    beforeEach(function() {
-      return this.PersistorManager.directorySize.callsArgWith(2)
-    })
-
-    return it('should call the filestore manager to get directory size', function(done) {
-      return this.handler.getDirectorySize(this.bucket, this.key, () => {
-        this.PersistorManager.directorySize
-          .calledWith(this.bucket, this.key)
-          .should.equal(true)
-        return done()
+  describe('getDirectorySize', function() {
+    it('should call the filestore manager to get directory size', function(done) {
+      FileHandler.getDirectorySize(bucket, key, err => {
+        expect(err).not.to.exist
+        expect(PersistorManager.directorySize).to.have.been.calledWith(
+          bucket,
+          key
+        )
+        done()
       })
     })
   })


### PR DESCRIPTION
### Description

One in a series of decaf-cleanup PRs. This cleans up and adds promise support for `FileHandler` and `LocalFileWriter`.

Original decaf work was in #60 
~Based onto #63~
Based onto #62

Trying to keep these as small as possible, but this one is a bit unwieldy, sorry.