### PR TITLE
Cleanup and promisify FileConverter

### DIFF
--- a/app/js/FileConverter.js
+++ b/app/js/FileConverter.js
@@ -90,17 +90,6 @@ async function _convert(sourcePath, requestedFormat, command) {
       timeout: FOURTY_SECONDS
     })
   } catch (err) {
-    logger.err(
-      {
-        err,
-        stderr: err.stderr,
-        command,
-        sourcePath,
-        requestedFormat,
-        destPath
-      },
-      'something went wrong converting file'
-    )
     throw new ConversionError({
       message: 'something went wrong converting file',
       info: { stderr: err.stderr, sourcePath, requestedFormat, destPath }

--- a/app/js/FileConverter.js
+++ b/app/js/FileConverter.js
@@ -1,133 +1,116 @@
-/* eslint-disable
-    camelcase,
-*/
-// TODO: This file was created by bulk-decaffeinate.
-// Fix any style issues and re-enable lint.
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * DS207: Consider shorter variations of null checks
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
-const _ = require('underscore')
 const metrics = require('metrics-sharelatex')
 const logger = require('logger-sharelatex')
-const safe_exec = require('./SafeExec')
-const approvedFormats = ['png']
 const Settings = require('settings-sharelatex')
+const { callbackify } = require('util')
 
-const fourtySeconds = 40 * 1000
+const safeExec = require('./SafeExec').promises
+const { ConversionError } = require('./Errors')
 
-const childProcessOpts = {
-  killSignal: 'SIGTERM',
-  timeout: fourtySeconds
-}
+const APPROVED_FORMATS = ['png']
+const FOURTY_SECONDS = 40 * 1000
+const KILL_SIGNAL = 'SIGTERM'
 
 module.exports = {
-  convert(sourcePath, requestedFormat, callback) {
-    logger.log({ sourcePath, requestedFormat }, 'converting file format')
-    const timer = new metrics.Timer('imageConvert')
-    const destPath = `${sourcePath}.${requestedFormat}`
-    sourcePath = `${sourcePath}[0]`
-    if (!_.include(approvedFormats, requestedFormat)) {
-      const err = new Error('invalid format requested')
-      return callback(err)
-    }
-    const width = '600x'
-    let command = [
-      'convert',
-      '-define',
-      `pdf:fit-page=${width}`,
-      '-flatten',
-      '-density',
-      '300',
-      sourcePath,
-      destPath
-    ]
-    command = Settings.commands.convertCommandPrefix.concat(command)
-    return safe_exec(command, childProcessOpts, function(err, stdout, stderr) {
-      timer.done()
-      if (err != null) {
-        logger.err(
-          { err, stderr, sourcePath, requestedFormat, destPath },
-          'something went wrong converting file'
-        )
-      } else {
-        logger.log(
-          { sourcePath, requestedFormat, destPath },
-          'finished converting file'
-        )
-      }
-      return callback(err, destPath)
-    })
-  },
+  convert: callbackify(convert),
+  thumbnail: callbackify(thumbnail),
+  preview: callbackify(preview),
+  promises: {
+    convert,
+    thumbnail,
+    preview
+  }
+}
 
-  thumbnail(sourcePath, callback) {
-    const destPath = `${sourcePath}.png`
-    sourcePath = `${sourcePath}[0]`
-    const width = '260x'
-    let command = [
-      'convert',
-      '-flatten',
-      '-background',
-      'white',
-      '-density',
-      '300',
-      '-define',
-      `pdf:fit-page=${width}`,
-      sourcePath,
-      '-resize',
-      width,
-      destPath
-    ]
-    logger.log({ sourcePath, destPath, command }, 'thumbnail convert file')
-    command = Settings.commands.convertCommandPrefix.concat(command)
-    return safe_exec(command, childProcessOpts, function(err, stdout, stderr) {
-      if (err != null) {
-        logger.err(
-          { err, stderr, sourcePath },
-          'something went wrong converting file to thumbnail'
-        )
-      } else {
-        logger.log({ sourcePath, destPath }, 'finished thumbnailing file')
-      }
-      return callback(err, destPath)
-    })
-  },
+async function convert(sourcePath, requestedFormat) {
+  const width = '600x'
+  return _convert(sourcePath, requestedFormat, [
+    'convert',
+    '-define',
+    `pdf:fit-page=${width}`,
+    '-flatten',
+    '-density',
+    '300',
+    `${sourcePath}[0]`
+  ])
+}
 
-  preview(sourcePath, callback) {
-    logger.log({ sourcePath }, 'preview convert file')
-    const destPath = `${sourcePath}.png`
-    sourcePath = `${sourcePath}[0]`
-    const width = '548x'
-    let command = [
-      'convert',
-      '-flatten',
-      '-background',
-      'white',
-      '-density',
-      '300',
-      '-define',
-      `pdf:fit-page=${width}`,
-      sourcePath,
-      '-resize',
-      width,
-      destPath
-    ]
-    command = Settings.commands.convertCommandPrefix.concat(command)
-    return safe_exec(command, childProcessOpts, function(err, stdout, stderr) {
-      if (err != null) {
-        logger.err(
-          { err, stderr, sourcePath, destPath },
-          'something went wrong converting file to preview'
-        )
-      } else {
-        logger.log(
-          { sourcePath, destPath },
-          'finished converting file to preview'
-        )
-      }
-      return callback(err, destPath)
+async function thumbnail(sourcePath) {
+  const width = '260x'
+  return convert(sourcePath, 'png', [
+    'convert',
+    '-flatten',
+    '-background',
+    'white',
+    '-density',
+    '300',
+    '-define',
+    `pdf:fit-page=${width}`,
+    `${sourcePath}[0]`,
+    '-resize',
+    width
+  ])
+}
+
+async function preview(sourcePath) {
+  const width = '548x'
+  return convert(sourcePath, 'png', [
+    'convert',
+    '-flatten',
+    '-background',
+    'white',
+    '-density',
+    '300',
+    '-define',
+    `pdf:fit-page=${width}`,
+    `${sourcePath}[0]`,
+    '-resize',
+    width
+  ])
+}
+
+async function _convert(sourcePath, requestedFormat, command) {
+  logger.log({ sourcePath, requestedFormat }, 'converting file format')
+
+  if (!APPROVED_FORMATS.includes(requestedFormat)) {
+    throw new ConversionError({
+      message: 'invalid format requested',
+      info: { format: requestedFormat }
     })
   }
+
+  const timer = new metrics.Timer('imageConvert')
+  const destPath = `${sourcePath}.${requestedFormat}`
+
+  command.push(destPath)
+  command = Settings.commands.convertCommandPrefix.concat(command)
+
+  try {
+    await safeExec(command, {
+      killSignal: KILL_SIGNAL,
+      timeout: FOURTY_SECONDS
+    })
+  } catch (err) {
+    logger.err(
+      {
+        err,
+        stderr: err.stderr,
+        command,
+        sourcePath,
+        requestedFormat,
+        destPath
+      },
+      'something went wrong converting file'
+    )
+    throw new ConversionError({
+      message: 'something went wrong converting file',
+      info: { stderr: err.stderr, sourcePath, requestedFormat, destPath }
+    }).withCause(err)
+  }
+
+  timer.done()
+  logger.log(
+    { sourcePath, requestedFormat, destPath },
+    'finished converting file'
+  )
+  return destPath
 }


### PR DESCRIPTION
### Description

Part of a series of decaf-cleanup PRs, starting at #60 
This one is targeted onto #64 

This cleans up and promisifies `FileConverter`. As well as promisification, I've also removed some duplicate code present in all of the different conversion methods.