### PR TITLE
Decaf and promisify ImageOptimiser

### DIFF
--- a/app/js/ImageOptimiser.js
+++ b/app/js/ImageOptimiser.js
@@ -1,44 +1,41 @@
-/* eslint-disable
-    no-unused-vars,
-*/
-// TODO: This file was created by bulk-decaffeinate.
-// Fix any style issues and re-enable lint.
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * DS207: Consider shorter variations of null checks
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
-const { exec } = require('child_process')
 const logger = require('logger-sharelatex')
-const Settings = require('settings-sharelatex')
+const metrics = require('metrics-sharelatex')
+const { callbackify } = require('util')
+const safeExec = require('./SafeExec').promises
 
 module.exports = {
-  compressPng(localPath, callback) {
-    const startTime = new Date()
-    logger.log({ localPath }, 'optimising png path')
-    const args = `optipng ${localPath}`
-    const opts = {
-      timeout: 30 * 1000,
-      killSignal: 'SIGKILL'
+  compressPng: callbackify(compressPng),
+  promises: {
+    compressPng
+  }
+}
+
+async function compressPng(localPath, callback) {
+  const timer = new metrics.Timer('compressPng')
+  logger.log({ localPath }, 'optimising png path')
+
+  const args = ['optipng', localPath]
+  const opts = {
+    timeout: 30 * 1000,
+    killSignal: 'SIGKILL'
+  }
+
+  try {
+    await safeExec(args, opts)
+    timer.done()
+    logger.log({ localPath }, 'finished compressing png')
+  } catch (err) {
+    if (err.code === 'SIGKILL') {
+      logger.warn(
+        { err, stderr: err.stderr, localPath },
+        'optimiser timeout reached'
+      )
+    } else {
+      logger.err(
+        { err, stderr: err.stderr, localPath },
+        'something went wrong compressing png'
+      )
+      throw err
     }
-    if (!Settings.enableConversions) {
-      const error = new Error('Image conversions are disabled')
-      return callback(error)
-    }
-    return exec(args, opts, function(err, stdout, stderr) {
-      if (err != null && err.signal === 'SIGKILL') {
-        logger.warn({ err, stderr, localPath }, 'optimiser timeout reached')
-        err = null
-      } else if (err != null) {
-        logger.err(
-          { err, stderr, localPath },
-          'something went wrong converting compressPng'
-        )
-      } else {
-        logger.log({ localPath }, 'finished compressPng file')
-      }
-      return callback(err)
-    })
   }
 }


### PR DESCRIPTION
### Description

Further cleanup of the decaf started in #60 
This PR cleans up `ImageOptimiser`, and is targeted onto #66 - there are many PRs in this chain as I am trying to spread out the review workload.

Removed the calls directly into `child_process` and instead call directly into `SafeExec`. This also checks that image optimisation is enabled, so removed the redundant check from here.