### PR TITLE
Simplify logging to log only once per http request

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,8 @@ const fileController = require('./app/js/FileController')
 const keyBuilder = require('./app/js/KeyBuilder')
 const healthCheckController = require('./app/js/HealthCheckController')
 
+const RequestLogger = require('./app/js/RequestLogger')
+
 const app = express()
 
 if (settings.sentry && settings.sentry.dsn) {
@@ -27,6 +29,7 @@ if (Metrics.event_loop) {
 app.use(Metrics.http.monitor(logger))
 app.use(function(req, res, next) {
   Metrics.inc('http-request')
+  res.logInfo = {}
   next()
 })
 
@@ -136,6 +139,9 @@ app.get('/status', function(req, res) {
 })
 
 app.get('/health_check', healthCheckController.check)
+
+app.use(RequestLogger.logRequest)
+app.use(RequestLogger.logError)
 
 const port = settings.internal.filestore.port || 3009
 const host = '0.0.0.0'

--- a/app/js/Errors.js
+++ b/app/js/Errors.js
@@ -24,6 +24,7 @@ class HealthCheckError extends BackwardCompatibleError {}
 class ConversionsDisabledError extends BackwardCompatibleError {}
 class ConversionError extends BackwardCompatibleError {}
 class SettingsError extends BackwardCompatibleError {}
+class TimeoutError extends BackwardCompatibleError {}
 
 class FailedCommandError extends OError {
   constructor(command, code, stdout, stderr) {
@@ -48,5 +49,6 @@ module.exports = {
   ReadError,
   ConversionError,
   HealthCheckError,
-  SettingsError
+  SettingsError,
+  TimeoutError
 }

--- a/app/js/FSPersistorManager.js
+++ b/app/js/FSPersistorManager.js
@@ -1,6 +1,5 @@
 const fs = require('fs')
 const glob = require('glob')
-const logger = require('logger-sharelatex')
 const path = require('path')
 const rimraf = require('rimraf')
 const Stream = require('stream')
@@ -20,7 +19,6 @@ const filterName = key => key.replace(/\//g, '_')
 
 async function sendFile(location, target, source) {
   const filteredTarget = filterName(target)
-  logger.log({ location, target: filteredTarget, source }, 'sending file')
 
   // actually copy the file (instead of moving it) to maintain consistent behaviour
   // between the different implementations
@@ -39,8 +37,6 @@ async function sendFile(location, target, source) {
 }
 
 async function sendStream(location, target, sourceStream) {
-  logger.log({ location, target }, 'sending file stream')
-
   const fsPath = await LocalFileWriter.writeStream(sourceStream)
 
   try {
@@ -53,13 +49,10 @@ async function sendStream(location, target, sourceStream) {
 // opts may be {start: Number, end: Number}
 async function getFileStream(location, name, opts) {
   const filteredName = filterName(name)
-  logger.log({ location, filteredName }, 'getting file')
 
   try {
     opts.fd = await fsOpen(`${location}/${filteredName}`, 'r')
   } catch (err) {
-    logger.err({ err, location, filteredName: name }, 'Error reading from file')
-
     throw _wrapError(
       err,
       'failed to open file for streaming',
@@ -78,8 +71,6 @@ async function getFileSize(location, filename) {
     const stat = await fsStat(fullPath)
     return stat.size
   } catch (err) {
-    logger.err({ err, location, filename }, 'failed to stat file')
-
     throw _wrapError(
       err,
       'failed to stat file',
@@ -92,7 +83,6 @@ async function getFileSize(location, filename) {
 async function copyFile(location, fromName, toName) {
   const filteredFromName = filterName(fromName)
   const filteredToName = filterName(toName)
-  logger.log({ location, filteredFromName, filteredToName }, 'copying file')
 
   try {
     const sourceStream = fs.createReadStream(`${location}/${filteredFromName}`)
@@ -110,7 +100,6 @@ async function copyFile(location, fromName, toName) {
 
 async function deleteFile(location, name) {
   const filteredName = filterName(name)
-  logger.log({ location, filteredName }, 'delete file')
   try {
     await fsUnlink(`${location}/${filteredName}`)
   } catch (err) {
@@ -126,8 +115,6 @@ async function deleteFile(location, name) {
 // this is only called internally for clean-up by `FileHandler` and isn't part of the external API
 async function deleteDirectory(location, name) {
   const filteredName = filterName(name.replace(/\/$/, ''))
-
-  logger.log({ location, filteredName }, 'deleting directory')
 
   try {
     await rmrf(`${location}/${filteredName}`)

--- a/app/js/FileController.js
+++ b/app/js/FileController.js
@@ -1,5 +1,4 @@
 const PersistorManager = require('./PersistorManager')
-const logger = require('logger-sharelatex')
 const FileHandler = require('./FileHandler')
 const metrics = require('metrics-sharelatex')
 const parseRange = require('range-parser')
@@ -26,18 +25,17 @@ function getFile(req, res, next) {
     format,
     style
   }
+
   metrics.inc('getFile')
-  logger.log({ key, bucket, format, style }, 'receiving request to get file')
+  res.logMsg = 'getting file'
+  res.logInfo = { key, bucket, format, style, cacheWarm: req.query.cacheWarm }
 
   if (req.headers.range) {
     const range = _getRange(req.headers.range)
     if (range) {
       options.start = range.start
       options.end = range.end
-      logger.log(
-        { start: range.start, end: range.end },
-        'getting range of bytes from file'
-      )
+      res.logInfo.range = range
     }
   }
 
@@ -45,69 +43,78 @@ function getFile(req, res, next) {
     if (err) {
       if (err instanceof Errors.NotFoundError) {
         res.sendStatus(404)
+        res.logInfo.notFound = true
+        next()
       } else {
-        logger.err({ err, key, bucket, format, style }, 'problem getting file')
-        res.sendStatus(500)
+        next(err)
       }
       return
     }
 
     if (req.query.cacheWarm) {
-      logger.log(
-        { key, bucket, format, style },
-        'request is only for cache warm so not sending stream'
-      )
-      return res.sendStatus(200)
+      res.sendStatus(200)
+      return next()
     }
-
-    logger.log({ key, bucket, format, style }, 'sending file to response')
 
     // pass 'next' as a callback to 'pipeline' to receive any errors
     pipeline(fileStream, res, next)
   })
 }
 
-function getFileHead(req, res) {
+function getFileHead(req, res, next) {
   const { key, bucket } = req
+
   metrics.inc('getFileSize')
-  logger.log({ key, bucket }, 'receiving request to get file metadata')
+  res.logMsg = 'getting file size'
+  res.logInfo = { key, bucket }
+
   FileHandler.getFileSize(bucket, key, function(err, fileSize) {
     if (err) {
       if (err instanceof Errors.NotFoundError) {
         res.sendStatus(404)
+        res.logInfo.notFound = true
+        next()
       } else {
-        res.sendStatus(500)
+        next(err)
       }
       return
     }
     res.set('Content-Length', fileSize)
     res.status(200).end()
+    next()
   })
 }
 
-function insertFile(req, res) {
+function insertFile(req, res, next) {
   metrics.inc('insertFile')
   const { key, bucket } = req
-  logger.log({ key, bucket }, 'receiving request to insert file')
+
+  res.logMsg = 'inserting file'
+  res.logInfo = { key, bucket }
+
   FileHandler.insertFile(bucket, key, req, function(err) {
     if (err) {
-      logger.log({ err, key, bucket }, 'error inserting file')
-      res.sendStatus(500)
+      next(err)
     } else {
       res.sendStatus(200)
+      next()
     }
   })
 }
 
-function copyFile(req, res) {
+function copyFile(req, res, next) {
   metrics.inc('copyFile')
   const { key, bucket } = req
   const oldProjectId = req.body.source.project_id
   const oldFileId = req.body.source.file_id
-  logger.log(
-    { key, bucket, oldProject_id: oldProjectId, oldFile_id: oldFileId },
-    'receiving request to copy file'
-  )
+
+  req.logInfo = {
+    key,
+    bucket,
+    oldProject_id: oldProjectId,
+    oldFile_id: oldFileId
+  }
+  req.logMsg = 'copying file'
 
   PersistorManager.copyFile(
     bucket,
@@ -117,46 +124,52 @@ function copyFile(req, res) {
       if (err) {
         if (err instanceof Errors.NotFoundError) {
           res.sendStatus(404)
+          res.logInfo.notFound = true
+          next()
         } else {
-          logger.log(
-            { err, oldProject_id: oldProjectId, oldFile_id: oldFileId },
-            'something went wrong copying file'
-          )
-          res.sendStatus(500)
+          next(err)
         }
         return
       }
 
       res.sendStatus(200)
+      next()
     }
   )
 }
 
-function deleteFile(req, res) {
+function deleteFile(req, res, next) {
   metrics.inc('deleteFile')
   const { key, bucket } = req
-  logger.log({ key, bucket }, 'receiving request to delete file')
-  return FileHandler.deleteFile(bucket, key, function(err) {
-    if (err != null) {
-      logger.log({ err, key, bucket }, 'something went wrong deleting file')
-      return res.sendStatus(500)
+
+  req.logInfo = { key, bucket }
+  req.logMsg = 'deleting file'
+
+  FileHandler.deleteFile(bucket, key, function(err) {
+    if (err) {
+      next(err)
     } else {
-      return res.sendStatus(204)
+      res.sendStatus(204)
+      next()
     }
   })
 }
 
-function directorySize(req, res) {
+function directorySize(req, res, next) {
   metrics.inc('projectSize')
   const { project_id: projectId, bucket } = req
-  logger.log({ projectId, bucket }, 'receiving request to project size')
+
+  req.logMsg = 'getting project size'
+  req.logInfo = { projectId, bucket }
+
   FileHandler.getDirectorySize(bucket, projectId, function(err, size) {
     if (err) {
-      logger.log({ err, projectId, bucket }, 'error inserting file')
-      return res.sendStatus(500)
+      return next(err)
     }
 
     res.json({ 'total bytes': size })
+    req.logInfo.size = size
+    next()
   })
 }
 

--- a/app/js/FileConverter.js
+++ b/app/js/FileConverter.js
@@ -1,5 +1,4 @@
 const metrics = require('metrics-sharelatex')
-const logger = require('logger-sharelatex')
 const Settings = require('settings-sharelatex')
 const { callbackify } = require('util')
 
@@ -69,8 +68,6 @@ async function preview(sourcePath) {
 }
 
 async function _convert(sourcePath, requestedFormat, command) {
-  logger.log({ sourcePath, requestedFormat }, 'converting file format')
-
   if (!APPROVED_FORMATS.includes(requestedFormat)) {
     throw new ConversionError({
       message: 'invalid format requested',
@@ -97,9 +94,5 @@ async function _convert(sourcePath, requestedFormat, command) {
   }
 
   timer.done()
-  logger.log(
-    { sourcePath, requestedFormat, destPath },
-    'finished converting file'
-  )
   return destPath
 }

--- a/app/js/HealthCheckController.js
+++ b/app/js/HealthCheckController.js
@@ -1,6 +1,5 @@
 const fs = require('fs-extra')
 const path = require('path')
-const logger = require('logger-sharelatex')
 const Settings = require('settings-sharelatex')
 const streamBuffers = require('stream-buffers')
 const { promisify } = require('util')
@@ -60,13 +59,11 @@ async function checkFileConvert() {
 }
 
 module.exports = {
-  check(req, res) {
-    logger.log({}, 'performing health check')
+  check(req, res, next) {
     Promise.all([checkCanGetFiles(), checkFileConvert()])
       .then(() => res.sendStatus(200))
       .catch(err => {
-        logger.err({ err }, 'Health check: error running')
-        res.sendStatus(500)
+        next(err)
       })
   }
 }

--- a/app/js/ImageOptimiser.js
+++ b/app/js/ImageOptimiser.js
@@ -12,8 +12,6 @@ module.exports = {
 
 async function compressPng(localPath, callback) {
   const timer = new metrics.Timer('compressPng')
-  logger.log({ localPath }, 'optimising png path')
-
   const args = ['optipng', localPath]
   const opts = {
     timeout: 30 * 1000,
@@ -23,7 +21,6 @@ async function compressPng(localPath, callback) {
   try {
     await safeExec(args, opts)
     timer.done()
-    logger.log({ localPath }, 'finished compressing png')
   } catch (err) {
     if (err.code === 'SIGKILL') {
       logger.warn(
@@ -31,10 +28,6 @@ async function compressPng(localPath, callback) {
         'optimiser timeout reached'
       )
     } else {
-      logger.err(
-        { err, stderr: err.stderr, localPath },
-        'something went wrong compressing png'
-      )
       throw err
     }
   }

--- a/app/js/LocalFileWriter.js
+++ b/app/js/LocalFileWriter.js
@@ -3,7 +3,6 @@ const uuid = require('node-uuid')
 const path = require('path')
 const Stream = require('stream')
 const { callbackify, promisify } = require('util')
-const logger = require('logger-sharelatex')
 const metrics = require('metrics-sharelatex')
 const Settings = require('settings-sharelatex')
 const { WriteError } = require('./Errors')
@@ -23,18 +22,14 @@ async function writeStream(stream, key) {
   const timer = new metrics.Timer('writingFile')
   const fsPath = _getPath(key)
 
-  logger.log({ fsPath }, 'writing file locally')
-
   const writeStream = fs.createWriteStream(fsPath)
   try {
     await pipeline(stream, writeStream)
     timer.done()
-    logger.log({ fsPath }, 'finished writing file locally')
     return fsPath
   } catch (err) {
     await deleteFile(fsPath)
 
-    logger.err({ err, fsPath }, 'problem writing file locally')
     throw new WriteError({
       message: 'problem writing file locally',
       info: { err, fsPath }
@@ -46,7 +41,6 @@ async function deleteFile(fsPath) {
   if (!fsPath) {
     return
   }
-  logger.log({ fsPath }, 'removing local temp file')
   try {
     await promisify(fs.unlink)(fsPath)
   } catch (err) {

--- a/app/js/RequestLogger.js
+++ b/app/js/RequestLogger.js
@@ -1,0 +1,32 @@
+const logger = require('logger-sharelatex')
+
+module.exports = {
+  logRequest,
+  logError
+}
+
+function logRequest(req, res) {
+  // response has already been sent, but we log what happened here
+  logger.log(
+    {
+      info: res.logInfo,
+      url: req.originalUrl,
+      params: req.params
+    },
+    res.logMsg || 'HTTP request'
+  )
+}
+
+function logError(err, req, res, next) {
+  logger.err(
+    {
+      err,
+      info: res.logInfo,
+      url: req.originalUrl,
+      params: req.params,
+      msg: res.logMsg
+    },
+    err.message
+  )
+  next(err) // use the standard error handler to send the response
+}

--- a/app/js/S3PersistorManager.js
+++ b/app/js/S3PersistorManager.js
@@ -4,7 +4,6 @@ http.globalAgent.maxSockets = 300
 https.globalAgent.maxSockets = 300
 
 const settings = require('settings-sharelatex')
-const logger = require('logger-sharelatex')
 const metrics = require('metrics-sharelatex')
 
 const meter = require('stream-meter')
@@ -64,15 +63,13 @@ async function sendStream(bucketName, key, readStream) {
       metrics.count('s3.egress', meteredStream.bytes)
     })
 
-    const response = await _getClientForBucket(bucketName)
+    await _getClientForBucket(bucketName)
       .upload({
         Bucket: bucketName,
         Key: key,
         Body: readStream.pipe(meteredStream)
       })
       .promise()
-
-    logger.log({ response, bucketName, key }, 'data uploaded to s3')
   } catch (err) {
     throw _wrapError(
       err,
@@ -116,7 +113,6 @@ async function getFileStream(bucketName, key, opts) {
 }
 
 async function deleteDirectory(bucketName, key) {
-  logger.log({ key, bucketName }, 'deleting directory')
   let response
 
   try {

--- a/test/unit/js/FSPersistorManagerTests.js
+++ b/test/unit/js/FSPersistorManagerTests.js
@@ -44,10 +44,6 @@ describe('FSPersistorManagerTests', function() {
     FSPersistorManager = SandboxedModule.require(modulePath, {
       requires: {
         './LocalFileWriter': LocalFileWriter,
-        'logger-sharelatex': {
-          log() {},
-          err() {}
-        },
         './Errors': Errors,
         fs,
         glob,

--- a/test/unit/js/FileConverterTests.js
+++ b/test/unit/js/FileConverterTests.js
@@ -25,10 +25,6 @@ describe('FileConverter', function() {
     FileConverter = SandboxedModule.require(modulePath, {
       requires: {
         './SafeExec': SafeExec,
-        'logger-sharelatex': {
-          log() {},
-          err() {}
-        },
         'metrics-sharelatex': {
           inc: sinon.stub(),
           Timer: sinon.stub().returns({ done: sinon.stub() })

--- a/test/unit/js/FileHandlerTests.js
+++ b/test/unit/js/FileHandlerTests.js
@@ -67,11 +67,7 @@ describe('FileHandler', function() {
         './FileConverter': FileConverter,
         './KeyBuilder': KeyBuilder,
         './ImageOptimiser': ImageOptimiser,
-        fs: fs,
-        'logger-sharelatex': {
-          log() {},
-          err() {}
-        }
+        fs: fs
       },
       globals: { console }
     })

--- a/test/unit/js/KeybuilderTests.js
+++ b/test/unit/js/KeybuilderTests.js
@@ -7,14 +7,7 @@ describe('LocalFileWriter', function() {
   const key = 'wombat/potato'
 
   beforeEach(function() {
-    KeyBuilder = SandboxedModule.require(modulePath, {
-      requires: {
-        'logger-sharelatex': {
-          log() {},
-          err() {}
-        }
-      }
-    })
+    KeyBuilder = SandboxedModule.require(modulePath)
   })
 
   describe('cachedKey', function() {

--- a/test/unit/js/LocalFileWriterTests.js
+++ b/test/unit/js/LocalFileWriterTests.js
@@ -26,10 +26,6 @@ describe('LocalFileWriter', function() {
       requires: {
         fs,
         stream,
-        'logger-sharelatex': {
-          log() {},
-          err() {}
-        },
         'settings-sharelatex': settings,
         'metrics-sharelatex': {
           inc: sinon.stub(),

--- a/test/unit/js/S3PersistorManagerTests.js
+++ b/test/unit/js/S3PersistorManagerTests.js
@@ -118,10 +118,6 @@ describe('S3PersistorManagerTests', function() {
         './Errors': Errors,
         fs: Fs,
         'stream-meter': Meter,
-        'logger-sharelatex': {
-          log() {},
-          err() {}
-        },
         'metrics-sharelatex': Metrics
       },
       globals: { console }

--- a/test/unit/js/SafeExecTests.js
+++ b/test/unit/js/SafeExecTests.js
@@ -13,10 +13,6 @@ describe('SafeExec', function() {
 
     safeExec = SandboxedModule.require(modulePath, {
       requires: {
-        'logger-sharelatex': {
-          log() {},
-          err() {}
-        },
         'settings-sharelatex': settings
       }
     })


### PR DESCRIPTION
### Description

An attempt to reduce log volume to (mostly) one log per request, as described in the logging proposal. Specifically, this does the following:

* Removes access to the logger from (almost) everywhere
* Adds a logging middleware to express, and a logging error handler
* Call either `next()` or `next(err)` from all non-health-check controller methods

This results in one happy-path log per request, *or* one error log.

#### Related Issues / PRs

This is currently hanging off my daisy-chain of branches, so currently points at #74 
The logging proposal is in overleaf/write_latex_ops#531

### Review

This is something of a draft/out-of-hours PR so I'm happy to accept bikeshedding or outright rejection here. :-)

The logging middleware allows us to write some context to the `res` object, which it will read before printing anything. This enables customisation of the log message.

If anything goes wrong, we wind up with an `OError` which we pass to `next(err)`, which will log the error and return `500` with the message from the error. This allows us to populate it with plenty of context, and removes the need for adding multiple error logs when things go awry.

Because of this, very little needs to `require('logger-sharelatex')`. One place where I *have* done this is in the `ImageOptimiser` as it otherwise swallows errors when the optimisation process ties out. This seems sensible behaviour as we already have a non-optimised png to serve, but it might be a useful thing to know about. - Another place is when initialising the `PersistorManager` as it may be helpful to have a log line saying what backend it's trying to boot.

This is one approach to the logging proposal and I'm sure there are plenty of others.