### PR TITLE
Handle AccessDenied and stream-premature-close errors

### DIFF
--- a/app/js/FileController.js
+++ b/app/js/FileController.js
@@ -62,8 +62,16 @@ function getFile(req, res, next) {
 
     logger.log({ key, bucket, format, style }, 'sending file to response')
 
-    // pass 'next' as a callback to 'pipeline' to receive any errors
-    pipeline(fileStream, res, next)
+    pipeline(fileStream, res, err => {
+      if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
+        logger.err(
+          new Errors.ReadError({
+            message: 'error transferring stream',
+            info: { bucket, key, format, style }
+          }).withCause(err)
+        )
+      }
+    })
   })
 }
 

--- a/app/js/S3PersistorManager.js
+++ b/app/js/S3PersistorManager.js
@@ -236,7 +236,9 @@ async function directorySize(bucketName, key) {
 }
 
 function _wrapError(error, message, params, ErrorType) {
-  if (['NoSuchKey', 'NotFound', 'ENOENT'].includes(error.code)) {
+  if (
+    ['NoSuchKey', 'NotFound', 'AccessDenied', 'ENOENT'].includes(error.code)
+  ) {
     return new NotFoundError({
       message: 'no such file',
       info: params


### PR DESCRIPTION
### Description

This will report `AccessDenied` from S3 as a 404, and not generate any log info when we get a `ERR_STREAM_PREMATURE_CLOSE` back from `pipeline`.

The former was happening anyway on the old version and generating errors in Stackdriver, but the errors look different now so generated a new alert in Sentry.