### PR TITLE
Simplify logging to only log once per request

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,8 @@ const fileController = require('./app/js/FileController')
 const keyBuilder = require('./app/js/KeyBuilder')
 const healthCheckController = require('./app/js/HealthCheckController')
 
+const RequestLogger = require('./app/js/RequestLogger')
+
 const app = express()
 
 if (settings.sentry && settings.sentry.dsn) {
@@ -27,6 +29,7 @@ if (Metrics.event_loop) {
 app.use(Metrics.http.monitor(logger))
 app.use(function(req, res, next) {
   Metrics.inc('http-request')
+  res.logInfo = {}
   next()
 })
 
@@ -136,6 +139,9 @@ app.get('/status', function(req, res) {
 })
 
 app.get('/health_check', healthCheckController.check)
+
+app.use(RequestLogger.logRequest)
+app.use(RequestLogger.logError)
 
 const port = settings.internal.filestore.port || 3009
 const host = '0.0.0.0'

--- a/app.js
+++ b/app.js
@@ -26,7 +26,9 @@ if (Metrics.event_loop) {
   Metrics.event_loop.monitor(logger)
 }
 
-app.use(Metrics.http.monitor(logger))
+app.use(RequestLogger.middleware)
+app.use(RequestLogger.errorHandler)
+
 app.use(function(req, res, next) {
   Metrics.inc('http-request')
   res.logInfo = {}
@@ -139,9 +141,6 @@ app.get('/status', function(req, res) {
 })
 
 app.get('/health_check', healthCheckController.check)
-
-app.use(RequestLogger.logRequest)
-app.use(RequestLogger.logError)
 
 const port = settings.internal.filestore.port || 3009
 const host = '0.0.0.0'

--- a/app.js
+++ b/app.js
@@ -16,8 +16,7 @@ const RequestLogger = require('./app/js/RequestLogger')
 
 const app = express()
 
-const requestLogger = new RequestLogger()
-requestLogger.attach(app)
+RequestLogger.attach(app)
 
 if (settings.sentry && settings.sentry.dsn) {
   logger.initializeErrorReporting(settings.sentry.dsn)

--- a/app.js
+++ b/app.js
@@ -16,6 +16,9 @@ const RequestLogger = require('./app/js/RequestLogger')
 
 const app = express()
 
+const requestLogger = new RequestLogger()
+requestLogger.attach(app)
+
 if (settings.sentry && settings.sentry.dsn) {
   logger.initializeErrorReporting(settings.sentry.dsn)
 }
@@ -25,9 +28,6 @@ Metrics.memory.monitor(logger)
 if (Metrics.event_loop) {
   Metrics.event_loop.monitor(logger)
 }
-
-app.use(RequestLogger.middleware)
-app.use(RequestLogger.errorHandler)
 
 app.use(function(req, res, next) {
   Metrics.inc('http-request')

--- a/app.js
+++ b/app.js
@@ -30,7 +30,6 @@ if (Metrics.event_loop) {
 
 app.use(function(req, res, next) {
   Metrics.inc('http-request')
-  res.logInfo = {}
   next()
 })
 

--- a/app/js/Errors.js
+++ b/app/js/Errors.js
@@ -24,6 +24,7 @@ class HealthCheckError extends BackwardCompatibleError {}
 class ConversionsDisabledError extends BackwardCompatibleError {}
 class ConversionError extends BackwardCompatibleError {}
 class SettingsError extends BackwardCompatibleError {}
+class TimeoutError extends BackwardCompatibleError {}
 
 class FailedCommandError extends OError {
   constructor(command, code, stdout, stderr) {
@@ -48,5 +49,6 @@ module.exports = {
   ReadError,
   ConversionError,
   HealthCheckError,
-  SettingsError
+  SettingsError,
+  TimeoutError
 }

--- a/app/js/FSPersistorManager.js
+++ b/app/js/FSPersistorManager.js
@@ -1,6 +1,5 @@
 const fs = require('fs')
 const glob = require('glob')
-const logger = require('logger-sharelatex')
 const path = require('path')
 const rimraf = require('rimraf')
 const Stream = require('stream')
@@ -20,7 +19,6 @@ const filterName = key => key.replace(/\//g, '_')
 
 async function sendFile(location, target, source) {
   const filteredTarget = filterName(target)
-  logger.log({ location, target: filteredTarget, source }, 'sending file')
 
   // actually copy the file (instead of moving it) to maintain consistent behaviour
   // between the different implementations
@@ -39,8 +37,6 @@ async function sendFile(location, target, source) {
 }
 
 async function sendStream(location, target, sourceStream) {
-  logger.log({ location, target }, 'sending file stream')
-
   const fsPath = await LocalFileWriter.writeStream(sourceStream)
 
   try {
@@ -53,13 +49,10 @@ async function sendStream(location, target, sourceStream) {
 // opts may be {start: Number, end: Number}
 async function getFileStream(location, name, opts) {
   const filteredName = filterName(name)
-  logger.log({ location, filteredName }, 'getting file')
 
   try {
     opts.fd = await fsOpen(`${location}/${filteredName}`, 'r')
   } catch (err) {
-    logger.err({ err, location, filteredName: name }, 'Error reading from file')
-
     throw _wrapError(
       err,
       'failed to open file for streaming',
@@ -78,8 +71,6 @@ async function getFileSize(location, filename) {
     const stat = await fsStat(fullPath)
     return stat.size
   } catch (err) {
-    logger.err({ err, location, filename }, 'failed to stat file')
-
     throw _wrapError(
       err,
       'failed to stat file',
@@ -92,7 +83,6 @@ async function getFileSize(location, filename) {
 async function copyFile(location, fromName, toName) {
   const filteredFromName = filterName(fromName)
   const filteredToName = filterName(toName)
-  logger.log({ location, filteredFromName, filteredToName }, 'copying file')
 
   try {
     const sourceStream = fs.createReadStream(`${location}/${filteredFromName}`)
@@ -110,7 +100,6 @@ async function copyFile(location, fromName, toName) {
 
 async function deleteFile(location, name) {
   const filteredName = filterName(name)
-  logger.log({ location, filteredName }, 'delete file')
   try {
     await fsUnlink(`${location}/${filteredName}`)
   } catch (err) {
@@ -126,8 +115,6 @@ async function deleteFile(location, name) {
 // this is only called internally for clean-up by `FileHandler` and isn't part of the external API
 async function deleteDirectory(location, name) {
   const filteredName = filterName(name.replace(/\/$/, ''))
-
-  logger.log({ location, filteredName }, 'deleting directory')
 
   try {
     await rmrf(`${location}/${filteredName}`)

--- a/app/js/FileController.js
+++ b/app/js/FileController.js
@@ -1,5 +1,4 @@
 const PersistorManager = require('./PersistorManager')
-const logger = require('logger-sharelatex')
 const FileHandler = require('./FileHandler')
 const metrics = require('metrics-sharelatex')
 const parseRange = require('range-parser')
@@ -26,18 +25,17 @@ function getFile(req, res, next) {
     format,
     style
   }
+
   metrics.inc('getFile')
-  logger.log({ key, bucket, format, style }, 'receiving request to get file')
+  res.logMsg = 'getting file'
+  res.logInfo = { key, bucket, format, style, cacheWarm: req.query.cacheWarm }
 
   if (req.headers.range) {
     const range = _getRange(req.headers.range)
     if (range) {
       options.start = range.start
       options.end = range.end
-      logger.log(
-        { start: range.start, end: range.end },
-        'getting range of bytes from file'
-      )
+      res.logInfo.range = range
     }
   }
 
@@ -45,77 +43,88 @@ function getFile(req, res, next) {
     if (err) {
       if (err instanceof Errors.NotFoundError) {
         res.sendStatus(404)
+        res.logInfo.notFound = true
+        next()
       } else {
-        logger.err({ err, key, bucket, format, style }, 'problem getting file')
-        res.sendStatus(500)
+        next(err)
       }
       return
     }
 
     if (req.query.cacheWarm) {
-      logger.log(
-        { key, bucket, format, style },
-        'request is only for cache warm so not sending stream'
-      )
-      return res.sendStatus(200)
+      res.sendStatus(200)
+      return next()
     }
-
-    logger.log({ key, bucket, format, style }, 'sending file to response')
 
     pipeline(fileStream, res, err => {
       if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
-        logger.err(
+        next(
           new Errors.ReadError({
             message: 'error transferring stream',
             info: { bucket, key, format, style }
           }).withCause(err)
         )
+      } else {
+        next()
       }
     })
   })
 }
 
-function getFileHead(req, res) {
+function getFileHead(req, res, next) {
   const { key, bucket } = req
+
   metrics.inc('getFileSize')
-  logger.log({ key, bucket }, 'receiving request to get file metadata')
+  res.logMsg = 'getting file size'
+  res.logInfo = { key, bucket }
+
   FileHandler.getFileSize(bucket, key, function(err, fileSize) {
     if (err) {
       if (err instanceof Errors.NotFoundError) {
         res.sendStatus(404)
+        res.logInfo.notFound = true
+        next()
       } else {
-        res.sendStatus(500)
+        next(err)
       }
       return
     }
     res.set('Content-Length', fileSize)
     res.status(200).end()
+    next()
   })
 }
 
-function insertFile(req, res) {
+function insertFile(req, res, next) {
   metrics.inc('insertFile')
   const { key, bucket } = req
-  logger.log({ key, bucket }, 'receiving request to insert file')
+
+  res.logMsg = 'inserting file'
+  res.logInfo = { key, bucket }
+
   FileHandler.insertFile(bucket, key, req, function(err) {
     if (err) {
-      logger.log({ err, key, bucket }, 'error inserting file')
-      res.sendStatus(500)
+      next(err)
     } else {
       res.sendStatus(200)
+      next()
     }
   })
 }
 
-function copyFile(req, res) {
+function copyFile(req, res, next) {
   metrics.inc('copyFile')
   const { key, bucket } = req
   const oldProjectId = req.body.source.project_id
   const oldFileId = req.body.source.file_id
-  logger.log(
-    { key, bucket, oldProject_id: oldProjectId, oldFile_id: oldFileId },
-    'receiving request to copy file'
-  )
+
+  req.logInfo = {
+    key,
+    bucket,
+    oldProject_id: oldProjectId,
+    oldFile_id: oldFileId
+  }
+  req.logMsg = 'copying file'
 
   PersistorManager.copyFile(
     bucket,
@@ -125,46 +134,52 @@ function copyFile(req, res) {
       if (err) {
         if (err instanceof Errors.NotFoundError) {
           res.sendStatus(404)
+          res.logInfo.notFound = true
+          next()
         } else {
-          logger.log(
-            { err, oldProject_id: oldProjectId, oldFile_id: oldFileId },
-            'something went wrong copying file'
-          )
-          res.sendStatus(500)
+          next(err)
         }
         return
       }
 
       res.sendStatus(200)
+      next()
     }
   )
 }
 
-function deleteFile(req, res) {
+function deleteFile(req, res, next) {
   metrics.inc('deleteFile')
   const { key, bucket } = req
-  logger.log({ key, bucket }, 'receiving request to delete file')
-  return FileHandler.deleteFile(bucket, key, function(err) {
-    if (err != null) {
-      logger.log({ err, key, bucket }, 'something went wrong deleting file')
-      return res.sendStatus(500)
+
+  req.logInfo = { key, bucket }
+  req.logMsg = 'deleting file'
+
+  FileHandler.deleteFile(bucket, key, function(err) {
+    if (err) {
+      next(err)
     } else {
-      return res.sendStatus(204)
+      res.sendStatus(204)
+      next()
     }
   })
 }
 
-function directorySize(req, res) {
+function directorySize(req, res, next) {
   metrics.inc('projectSize')
   const { project_id: projectId, bucket } = req
-  logger.log({ projectId, bucket }, 'receiving request to project size')
+
+  req.logMsg = 'getting project size'
+  req.logInfo = { projectId, bucket }
+
   FileHandler.getDirectorySize(bucket, projectId, function(err, size) {
     if (err) {
-      logger.log({ err, projectId, bucket }, 'error inserting file')
-      return res.sendStatus(500)
+      return next(err)
     }
 
     res.json({ 'total bytes': size })
+    req.logInfo.size = size
+    next()
   })
 }
 

--- a/app/js/FileController.js
+++ b/app/js/FileController.js
@@ -27,8 +27,8 @@ function getFile(req, res, next) {
   }
 
   metrics.inc('getFile')
-  req.setLogMessage('getting file')
-  req.addLogFields({
+  req.requestLogger.setMessage('getting file')
+  req.requestLogger.addFields({
     key,
     bucket,
     format,
@@ -41,7 +41,7 @@ function getFile(req, res, next) {
     if (range) {
       options.start = range.start
       options.end = range.end
-      req.addLogField('range', range)
+      req.requestLogger.addFields({ range })
     }
   }
 
@@ -76,8 +76,8 @@ function getFileHead(req, res, next) {
   const { key, bucket } = req
 
   metrics.inc('getFileSize')
-  req.setLogMessage('getting file size')
-  req.addLogFields({ key, bucket })
+  req.requestLogger.setMessage('getting file size')
+  req.requestLogger.addFields({ key, bucket })
 
   FileHandler.getFileSize(bucket, key, function(err, fileSize) {
     if (err) {
@@ -97,8 +97,8 @@ function insertFile(req, res, next) {
   metrics.inc('insertFile')
   const { key, bucket } = req
 
-  req.setLogMessage('inserting file')
-  req.addLogFields({ key, bucket })
+  req.requestLogger.setMessage('inserting file')
+  req.requestLogger.addFields({ key, bucket })
 
   FileHandler.insertFile(bucket, key, req, function(err) {
     if (err) {
@@ -115,13 +115,13 @@ function copyFile(req, res, next) {
   const oldProjectId = req.body.source.project_id
   const oldFileId = req.body.source.file_id
 
-  req.addLogFields({
+  req.requestLogger.addFields({
     key,
     bucket,
     oldProject_id: oldProjectId,
     oldFile_id: oldFileId
   })
-  req.setLogMessage('copying file')
+  req.requestLogger.setMessage('copying file')
 
   PersistorManager.copyFile(
     bucket,
@@ -146,8 +146,8 @@ function deleteFile(req, res, next) {
   metrics.inc('deleteFile')
   const { key, bucket } = req
 
-  req.addLogFields({ key, bucket })
-  req.setLogMessage('deleting file')
+  req.requestLogger.addFields({ key, bucket })
+  req.requestLogger.setMessage('deleting file')
 
   FileHandler.deleteFile(bucket, key, function(err) {
     if (err) {
@@ -162,8 +162,8 @@ function directorySize(req, res, next) {
   metrics.inc('projectSize')
   const { project_id: projectId, bucket } = req
 
-  req.setLogMessage('getting project size')
-  req.addLogFields({ projectId, bucket })
+  req.requestLogger.setMessage('getting project size')
+  req.requestLogger.addFields({ projectId, bucket })
 
   FileHandler.getDirectorySize(bucket, projectId, function(err, size) {
     if (err) {
@@ -171,7 +171,7 @@ function directorySize(req, res, next) {
     }
 
     res.json({ 'total bytes': size })
-    req.addLogField('size', size)
+    req.requestLogger.addFields({ size })
   })
 }
 

--- a/app/js/FileConverter.js
+++ b/app/js/FileConverter.js
@@ -1,5 +1,4 @@
 const metrics = require('metrics-sharelatex')
-const logger = require('logger-sharelatex')
 const Settings = require('settings-sharelatex')
 const { callbackify } = require('util')
 
@@ -69,8 +68,6 @@ async function preview(sourcePath) {
 }
 
 async function _convert(sourcePath, requestedFormat, command) {
-  logger.log({ sourcePath, requestedFormat }, 'converting file format')
-
   if (!APPROVED_FORMATS.includes(requestedFormat)) {
     throw new ConversionError({
       message: 'invalid format requested',
@@ -97,9 +94,5 @@ async function _convert(sourcePath, requestedFormat, command) {
   }
 
   timer.done()
-  logger.log(
-    { sourcePath, requestedFormat, destPath },
-    'finished converting file'
-  )
   return destPath
 }

--- a/app/js/HealthCheckController.js
+++ b/app/js/HealthCheckController.js
@@ -1,6 +1,5 @@
 const fs = require('fs-extra')
 const path = require('path')
-const logger = require('logger-sharelatex')
 const Settings = require('settings-sharelatex')
 const streamBuffers = require('stream-buffers')
 const { promisify } = require('util')
@@ -60,13 +59,11 @@ async function checkFileConvert() {
 }
 
 module.exports = {
-  check(req, res) {
-    logger.log({}, 'performing health check')
+  check(req, res, next) {
     Promise.all([checkCanGetFiles(), checkFileConvert()])
       .then(() => res.sendStatus(200))
       .catch(err => {
-        logger.err({ err }, 'Health check: error running')
-        res.sendStatus(500)
+        next(err)
       })
   }
 }

--- a/app/js/ImageOptimiser.js
+++ b/app/js/ImageOptimiser.js
@@ -12,8 +12,6 @@ module.exports = {
 
 async function compressPng(localPath, callback) {
   const timer = new metrics.Timer('compressPng')
-  logger.log({ localPath }, 'optimising png path')
-
   const args = ['optipng', localPath]
   const opts = {
     timeout: 30 * 1000,
@@ -23,7 +21,6 @@ async function compressPng(localPath, callback) {
   try {
     await safeExec(args, opts)
     timer.done()
-    logger.log({ localPath }, 'finished compressing png')
   } catch (err) {
     if (err.code === 'SIGKILL') {
       logger.warn(
@@ -31,10 +28,6 @@ async function compressPng(localPath, callback) {
         'optimiser timeout reached'
       )
     } else {
-      logger.err(
-        { err, stderr: err.stderr, localPath },
-        'something went wrong compressing png'
-      )
       throw err
     }
   }

--- a/app/js/LocalFileWriter.js
+++ b/app/js/LocalFileWriter.js
@@ -3,7 +3,6 @@ const uuid = require('node-uuid')
 const path = require('path')
 const Stream = require('stream')
 const { callbackify, promisify } = require('util')
-const logger = require('logger-sharelatex')
 const metrics = require('metrics-sharelatex')
 const Settings = require('settings-sharelatex')
 const { WriteError } = require('./Errors')
@@ -23,18 +22,14 @@ async function writeStream(stream, key) {
   const timer = new metrics.Timer('writingFile')
   const fsPath = _getPath(key)
 
-  logger.log({ fsPath }, 'writing file locally')
-
   const writeStream = fs.createWriteStream(fsPath)
   try {
     await pipeline(stream, writeStream)
     timer.done()
-    logger.log({ fsPath }, 'finished writing file locally')
     return fsPath
   } catch (err) {
     await deleteFile(fsPath)
 
-    logger.err({ err, fsPath }, 'problem writing file locally')
     throw new WriteError({
       message: 'problem writing file locally',
       info: { err, fsPath }
@@ -46,7 +41,6 @@ async function deleteFile(fsPath) {
   if (!fsPath) {
     return
   }
-  logger.log({ fsPath }, 'removing local temp file')
   try {
     await promisify(fs.unlink)(fsPath)
   } catch (err) {

--- a/app/js/RequestLogger.js
+++ b/app/js/RequestLogger.js
@@ -1,83 +1,90 @@
 const logger = require('logger-sharelatex')
 const metrics = require('metrics-sharelatex')
 
-module.exports = {
-  errorHandler,
-  middleware
-}
-
-function errorHandler(err, req, res, next) {
-  req._logInfo.set('error', err)
-  res
-    .send(err.message)
-    .status(500)
-    .end()
-}
-
-function middleware(req, res, next) {
-  const startTime = new Date()
-
-  // methods to allow the setting of additional information to be logged for the request
-  req._logInfo = {}
-  req._logMessage = 'http request'
-  req.addLogField = function(field, value) {
-    req._logInfo[field] = value
-  }
-  req.addLogFields = function(fields) {
-    Object.assign(req._logInfo, fields)
-  }
-  req.setLogMessage = function(message) {
-    req._logMessage = message
+class RequestLogger {
+  constructor() {
+    this.errorHandler = this.errorHandler.bind(this)
+    this.middleware = this.middleware.bind(this)
+    this._logInfo = {}
+    this._logMessage = 'http request'
   }
 
-  // override the 'end' method to log and record metrics
-  const end = res.end
-  res.end = function() {
-    // apply the standard request 'end' method before logging and metrics
-    end.apply(this, arguments)
+  attach(app) {
+    app.use(this.middleware)
+    app.use(this.errorHandler)
+  }
 
-    const responseTime = new Date() - startTime
+  errorHandler(err, req, res, next) {
+    this._logInfo.error = err
+    res
+      .send(err.message)
+      .status(500)
+      .end()
+  }
 
-    const routePath = req.route && req.route.path.toString()
+  addFields(fields) {
+    Object.assign(this._logInfo, fields)
+  }
 
-    if (routePath) {
-      metrics.timing('http_request', responseTime, null, {
-        method: req.method,
-        status_code: res.statusCode,
-        path: routePath
-          .replace(/\//g, '_')
-          .replace(/:/g, '')
-          .slice(1)
-      })
+  setMessage(message) {
+    this._logMessage = message
+  }
+
+  middleware(req, res, next) {
+    const startTime = new Date()
+    req.requestLogger = this
+
+    // override the 'end' method to log and record metrics
+    const end = res.end
+    res.end = function() {
+      // apply the standard request 'end' method before logging and metrics
+      end.apply(this, arguments)
+
+      const responseTime = new Date() - startTime
+
+      const routePath = req.route && req.route.path.toString()
+
+      if (routePath) {
+        metrics.timing('http_request', responseTime, null, {
+          method: req.method,
+          status_code: res.statusCode,
+          path: routePath
+            .replace(/\//g, '_')
+            .replace(/:/g, '')
+            .slice(1)
+        })
+      }
+
+      const level = res.statusCode >= 500 ? 'err' : 'log'
+      logger[level](
+        {
+          req: {
+            url: req.originalUrl || req.url,
+            route: routePath,
+            method: req.method,
+            referrer: req.headers.referer || req.headers.referrer,
+            'remote-addr':
+              req.ip ||
+              (req.socket && req.socket.remoteAddress) ||
+              (req.socket &&
+                req.socket.socket &&
+                req.socket.socket.remoteAddress),
+            'user-agent': req.headers['user-agent'],
+            'content-length': req.headers['content-length']
+          },
+          res: {
+            'content-length': res._headers['content-length'],
+            statusCode: res.statusCode,
+            'response-time': responseTime
+          },
+          info: this._logInfo
+        },
+        this._logMessage
+      )
     }
 
-    const level = res.statusCode >= 500 ? 'err' : 'log'
-    logger[level](
-      {
-        req: {
-          url: req.originalUrl || req.url,
-          route: routePath,
-          method: req.method,
-          referrer: req.headers.referer || req.headers.referrer,
-          'remote-addr':
-            req.ip ||
-            (req.socket && req.socket.remoteAddress) ||
-            (req.socket &&
-              req.socket.socket &&
-              req.socket.socket.remoteAddress),
-          'user-agent': req.headers['user-agent'],
-          'content-length': req.headers['content-length']
-        },
-        res: {
-          'content-length': res._headers['content-length'],
-          statusCode: res.statusCode,
-          'response-time': responseTime
-        },
-        info: req._logInfo
-      },
-      req._logMessage
-    )
+    next()
   }
-
-  next()
 }
+
+module.exports = RequestLogger

--- a/app/js/RequestLogger.js
+++ b/app/js/RequestLogger.js
@@ -1,32 +1,83 @@
 const logger = require('logger-sharelatex')
+const metrics = require('metrics-sharelatex')
 
 module.exports = {
-  logRequest,
-  logError
+  errorHandler,
+  middleware
 }
 
-function logRequest(req, res) {
-  // response has already been sent, but we log what happened here
-  logger.log(
-    {
-      info: res.logInfo,
-      url: req.originalUrl,
-      params: req.params
-    },
-    res.logMsg || 'HTTP request'
-  )
+function errorHandler(err, req, res, next) {
+  req._logInfo.set('error', err)
+  res
+    .send(err.message)
+    .status(500)
+    .end()
 }
 
-function logError(err, req, res, next) {
-  logger.err(
-    {
-      err,
-      info: res.logInfo,
-      url: req.originalUrl,
-      params: req.params,
-      msg: res.logMsg
-    },
-    err.message
-  )
-  next(err) // use the standard error handler to send the response
+function middleware(req, res, next) {
+  const startTime = new Date()
+
+  // methods to allow the setting of additional information to be logged for the request
+  req._logInfo = {}
+  req._logMessage = 'http request'
+  req.addLogField = function(field, value) {
+    req._logInfo[field] = value
+  }
+  req.addLogFields = function(fields) {
+    Object.assign(req._logInfo, fields)
+  }
+  req.setLogMessage = function(message) {
+    req._logMessage = message
+  }
+
+  // override the 'end' method to log and record metrics
+  const end = res.end
+  res.end = function() {
+    // apply the standard request 'end' method before logging and metrics
+    end.apply(this, arguments)
+
+    const responseTime = new Date() - startTime
+
+    const routePath = req.route && req.route.path.toString()
+
+    if (routePath) {
+      metrics.timing('http_request', responseTime, null, {
+        method: req.method,
+        status_code: res.statusCode,
+        path: routePath
+          .replace(/\//g, '_')
+          .replace(/:/g, '')
+          .slice(1)
+      })
+    }
+
+    const level = res.statusCode >= 500 ? 'err' : 'log'
+    logger[level](
+      {
+        req: {
+          url: req.originalUrl || req.url,
+          route: routePath,
+          method: req.method,
+          referrer: req.headers.referer || req.headers.referrer,
+          'remote-addr':
+            req.ip ||
+            (req.socket && req.socket.remoteAddress) ||
+            (req.socket &&
+              req.socket.socket &&
+              req.socket.socket.remoteAddress),
+          'user-agent': req.headers['user-agent'],
+          'content-length': req.headers['content-length']
+        },
+        res: {
+          'content-length': res._headers['content-length'],
+          statusCode: res.statusCode,
+          'response-time': responseTime
+        },
+        info: req._logInfo
+      },
+      req._logMessage
+    )
+  }
+
+  next()
 }

--- a/app/js/RequestLogger.js
+++ b/app/js/RequestLogger.js
@@ -1,0 +1,32 @@
+const logger = require('logger-sharelatex')
+
+module.exports = {
+  logRequest,
+  logError
+}
+
+function logRequest(req, res) {
+  // response has already been sent, but we log what happened here
+  logger.log(
+    {
+      info: res.logInfo,
+      url: req.originalUrl,
+      params: req.params
+    },
+    res.logMsg || 'HTTP request'
+  )
+}
+
+function logError(err, req, res, next) {
+  logger.err(
+    {
+      err,
+      info: res.logInfo,
+      url: req.originalUrl,
+      params: req.params,
+      msg: res.logMsg
+    },
+    err.message
+  )
+  next(err) // use the standard error handler to send the response
+}

--- a/app/js/S3PersistorManager.js
+++ b/app/js/S3PersistorManager.js
@@ -4,7 +4,6 @@ http.globalAgent.maxSockets = 300
 https.globalAgent.maxSockets = 300
 
 const settings = require('settings-sharelatex')
-const logger = require('logger-sharelatex')
 const metrics = require('metrics-sharelatex')
 
 const meter = require('stream-meter')
@@ -64,15 +63,13 @@ async function sendStream(bucketName, key, readStream) {
       metrics.count('s3.egress', meteredStream.bytes)
     })
 
-    const response = await _getClientForBucket(bucketName)
+    await _getClientForBucket(bucketName)
       .upload({
         Bucket: bucketName,
         Key: key,
         Body: readStream.pipe(meteredStream)
       })
       .promise()
-
-    logger.log({ response, bucketName, key }, 'data uploaded to s3')
   } catch (err) {
     throw _wrapError(
       err,
@@ -116,7 +113,6 @@ async function getFileStream(bucketName, key, opts) {
 }
 
 async function deleteDirectory(bucketName, key) {
-  logger.log({ key, bucketName }, 'deleting directory')
   let response
 
   try {

--- a/test/unit/js/FSPersistorManagerTests.js
+++ b/test/unit/js/FSPersistorManagerTests.js
@@ -44,10 +44,6 @@ describe('FSPersistorManagerTests', function() {
     FSPersistorManager = SandboxedModule.require(modulePath, {
       requires: {
         './LocalFileWriter': LocalFileWriter,
-        'logger-sharelatex': {
-          log() {},
-          err() {}
-        },
         './Errors': Errors,
         fs,
         glob,

--- a/test/unit/js/FileControllerTests.js
+++ b/test/unit/js/FileControllerTests.js
@@ -73,9 +73,10 @@ describe('FileController', function() {
         file_id: fileId
       },
       headers: {},
-      setLogMessage: sinon.stub(),
-      addLogField: sinon.stub(),
-      addLogFields: sinon.stub()
+      requestLogger: {
+        setMessage: sinon.stub(),
+        addFields: sinon.stub()
+      }
     }
 
     res = {

--- a/test/unit/js/FileControllerTests.js
+++ b/test/unit/js/FileControllerTests.js
@@ -72,7 +72,10 @@ describe('FileController', function() {
         project_id: projectId,
         file_id: fileId
       },
-      headers: {}
+      headers: {},
+      setLogMessage: sinon.stub(),
+      addLogField: sinon.stub(),
+      addLogFields: sinon.stub()
     }
 
     res = {

--- a/test/unit/js/FileConverterTests.js
+++ b/test/unit/js/FileConverterTests.js
@@ -25,10 +25,6 @@ describe('FileConverter', function() {
     FileConverter = SandboxedModule.require(modulePath, {
       requires: {
         './SafeExec': SafeExec,
-        'logger-sharelatex': {
-          log() {},
-          err() {}
-        },
         'metrics-sharelatex': {
           inc: sinon.stub(),
           Timer: sinon.stub().returns({ done: sinon.stub() })

--- a/test/unit/js/FileHandlerTests.js
+++ b/test/unit/js/FileHandlerTests.js
@@ -67,11 +67,7 @@ describe('FileHandler', function() {
         './FileConverter': FileConverter,
         './KeyBuilder': KeyBuilder,
         './ImageOptimiser': ImageOptimiser,
-        fs: fs,
-        'logger-sharelatex': {
-          log() {},
-          err() {}
-        }
+        fs: fs
       },
       globals: { console }
     })

--- a/test/unit/js/KeybuilderTests.js
+++ b/test/unit/js/KeybuilderTests.js
@@ -7,14 +7,7 @@ describe('LocalFileWriter', function() {
   const key = 'wombat/potato'
 
   beforeEach(function() {
-    KeyBuilder = SandboxedModule.require(modulePath, {
-      requires: {
-        'logger-sharelatex': {
-          log() {},
-          err() {}
-        }
-      }
-    })
+    KeyBuilder = SandboxedModule.require(modulePath)
   })
 
   describe('cachedKey', function() {

--- a/test/unit/js/LocalFileWriterTests.js
+++ b/test/unit/js/LocalFileWriterTests.js
@@ -26,10 +26,6 @@ describe('LocalFileWriter', function() {
       requires: {
         fs,
         stream,
-        'logger-sharelatex': {
-          log() {},
-          err() {}
-        },
         'settings-sharelatex': settings,
         'metrics-sharelatex': {
           inc: sinon.stub(),

--- a/test/unit/js/S3PersistorManagerTests.js
+++ b/test/unit/js/S3PersistorManagerTests.js
@@ -122,10 +122,6 @@ describe('S3PersistorManagerTests', function() {
         './Errors': Errors,
         fs: Fs,
         'stream-meter': Meter,
-        'logger-sharelatex': {
-          log() {},
-          err() {}
-        },
         'metrics-sharelatex': Metrics
       },
       globals: { console }

--- a/test/unit/js/SafeExecTests.js
+++ b/test/unit/js/SafeExecTests.js
@@ -13,10 +13,6 @@ describe('SafeExec', function() {
 
     safeExec = SandboxedModule.require(modulePath, {
       requires: {
-        'logger-sharelatex': {
-          log() {},
-          err() {}
-        },
         'settings-sharelatex': settings
       }
     })


### PR DESCRIPTION
**Re-opening of #75**

Accidentally closed that PR by cleaning up some stale branches, and now I can't reopen it again.

### Description

An attempt to reduce log volume to (mostly) one log per request, as described in the logging proposal. Specifically, this does the following:

* Removes access to the logger from (almost) everywhere
* Adds a logging middleware to express, and a logging error handler
* Call either `next()` or `next(err)` from all non-health-check controller methods

This results in one happy-path log per request, *or* one error log.

#### Related Issues / PRs

Previously opened as #75
The logging proposal is in overleaf/write_latex_ops#531

### Review

In addition to the comments made in the previous PR, I took the logic from `metrics-sharelatex`'s HTTP monitor, which records timing info for the http methods as well as acting as a request logger itself. This avoids getting two messages per request.

Additionally, this logic (which overrides `res.end`) means that you don't have to call `next` in the controller methods except in the case of an error, which is an improvement. (`end` is always called by the framework even if you don't call it explicitly)

Force-pushed the branch to resolve a conflict with master, but the only changes from the previous PR are in the second commit here.