### PR TITLE
[misc] cleanup install deps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,7 @@ gitrev
 .npm
 .nvmrc
 nodemon.json
+
+uploads/
+user_files/
+template_files/

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,15 +1,14 @@
 #!/bin/sh
+
+set -ex
+
 apt-get update
 
-apt-get install vim imagemagick optipng --yes
+apt-get install ghostscript imagemagick optipng --yes
 
-wget -q https://s3.amazonaws.com/sl-public-dev-assets/ghostscript-9.15.tar.gz -O /tmp/ghostscript-9.15.tar.gz
-cd /tmp
-tar -xvf /tmp/ghostscript-9.15.tar.gz
-cd /tmp/ghostscript-9.15 && ./configure && make && make install
-npm rebuild
+rm -rf /var/lib/apt/lists/*
+
 mkdir /app/user_files/ /app/uploads/ /app/template_files/
 chown -R node:node /app/user_files
 chown -R node:node /app/uploads
 chown -R node:node /app/template_files
-ls -al /app


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description
I happen to have to rebuild the docker image again and it took ages. A quick inspection showed that you are still building an ancient version of ghostscript from source. We are using the debian package for imagemagick, so it should be fine to use their ghostscript package too. It is likely that they retain compatibility between the two, would on jump out of the line.

Program failures during the install_deps stage are no longer discarded, which reviled that the data dirs are included into the docker image - this was likely the trigger for the rebuild mentioned earlier. The data dirs are excluded from the COPY stage.

#### Potential Impact

Low, ghostscript is used for pdf to image conversion, which we do not allow in production.

#### Manual Testing Performed

- _[There is an acceptance test for the conversion](https://github.com/overleaf/filestore/blob/c8f869293273af3e6251f8d7bab714cea388cf96/test/acceptance/js/FilestoreTests.js#L335-L384) which passed._
