### PR TITLE
Fix log info assignment in error handler

### DIFF
--- a/app/js/RequestLogger.js
+++ b/app/js/RequestLogger.js
@@ -21,7 +21,7 @@ class RequestLogger {
   }
 
   static errorHandler(err, req, res, next) {
-    this._logInfo.error = err
+    req.requestLogger._logInfo.error = err
     res
       .send(err.message)
       .status(500)


### PR DESCRIPTION
### Description

The line in the error handler to assign the error variable to the request handler was incorrect.

### Review

The handler is static, and so `this._logInfo` does not make any sense here. We should use the `requestLogger` object on the request instead.
