### PR TITLE
Move error handler to be the last middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,7 @@ const RequestLogger = require('./app/js/RequestLogger')
 
 const app = express()
 
-RequestLogger.attach(app)
+app.use(RequestLogger.middleware)
 
 if (settings.sentry && settings.sentry.dsn) {
   logger.initializeErrorReporting(settings.sentry.dsn)
@@ -139,6 +139,8 @@ app.get('/status', function(req, res) {
 })
 
 app.get('/health_check', healthCheckController.check)
+
+app.use(RequestLogger.errorHandler)
 
 const port = settings.internal.filestore.port || 3009
 const host = '0.0.0.0'

--- a/app/js/RequestLogger.js
+++ b/app/js/RequestLogger.js
@@ -15,13 +15,8 @@ class RequestLogger {
     this._logMessage = message
   }
 
-  static attach(app) {
-    app.use(RequestLogger.middleware)
-    app.use(RequestLogger.errorHandler)
-  }
-
   static errorHandler(err, req, res, next) {
-    req.requestLogger._logInfo.error = err
+    req.requestLogger.addFields({ error: err })
     res
       .send(err.message)
       .status(500)


### PR DESCRIPTION
### Description

I missed the part where it says "You define error-handling middleware last, after other app.use() and routes calls" in https://expressjs.com/en/guide/error-handling.html - so the error handler isn't firing. This means that the logged errors to not include the `error` object.

This moves things around to fix that.

#### Potential Impact

Only affects the way that errors are reported
