### PR TITLE
Fix eTags not being in md5 format for large files

### DIFF
--- a/app/js/S3Persistor.js
+++ b/app/js/S3Persistor.js
@@ -96,7 +96,7 @@ async function sendStream(bucketName, key, readStream, sourceMd5) {
     }
 
     const response = await _getClientForBucket(bucketName)
-      .upload(uploadOptions, { partSize: 100 * 1024 * 1024 })
+      .upload(uploadOptions, { partSize: settings.filestore.s3.partSize })
       .promise()
     let destMd5 = _md5FromResponse(response)
     if (!destMd5) {

--- a/app/js/S3Persistor.js
+++ b/app/js/S3Persistor.js
@@ -96,7 +96,7 @@ async function sendStream(bucketName, key, readStream, sourceMd5) {
     }
 
     const response = await _getClientForBucket(bucketName)
-      .upload(uploadOptions)
+      .upload(uploadOptions, { partSize: 100 * 1024 * 1024 })
       .promise()
     const destMd5 = _md5FromResponse(response)
 

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -38,6 +38,7 @@ settings =
 				key: process.env['AWS_ACCESS_KEY_ID']
 				secret: process.env['AWS_SECRET_ACCESS_KEY']
 				endpoint: process.env['AWS_S3_ENDPOINT']
+				partSize: process.env['S3_PARTSIZE'] or (100 * 1024 * 1024)
 
 		stores:
 			user_files: process.env['USER_FILES_BUCKET_NAME']

--- a/test/acceptance/js/FilestoreTests.js
+++ b/test/acceptance/js/FilestoreTests.js
@@ -57,7 +57,8 @@ const BackendSettings = {
       key: process.env.AWS_ACCESS_KEY_ID,
       secret: process.env.AWS_SECRET_ACCESS_KEY,
       endpoint: process.env.AWS_S3_ENDPOINT,
-      pathStyle: true
+      pathStyle: true,
+      partSize: 100 * 1024 * 1024
     },
     stores: {
       user_files: process.env.AWS_S3_USER_FILES_BUCKET_NAME,
@@ -71,7 +72,8 @@ const BackendSettings = {
       key: process.env.AWS_ACCESS_KEY_ID,
       secret: process.env.AWS_SECRET_ACCESS_KEY,
       endpoint: process.env.AWS_S3_ENDPOINT,
-      pathStyle: true
+      pathStyle: true,
+      partSize: 100 * 1024 * 1024
     },
     stores: {
       user_files: process.env.AWS_S3_USER_FILES_BUCKET_NAME,
@@ -102,7 +104,8 @@ const BackendSettings = {
       key: process.env.AWS_ACCESS_KEY_ID,
       secret: process.env.AWS_SECRET_ACCESS_KEY,
       endpoint: process.env.AWS_S3_ENDPOINT,
-      pathStyle: true
+      pathStyle: true,
+      partSize: 100 * 1024 * 1024
     },
     stores: {
       user_files: Path.resolve(__dirname, '../../../user_files'),

--- a/test/unit/js/S3PersistorTests.js
+++ b/test/unit/js/S3PersistorTests.js
@@ -53,7 +53,8 @@ describe('S3PersistorTests', function() {
         backend: 's3',
         s3: {
           secret: defaultS3Secret,
-          key: defaultS3Key
+          key: defaultS3Key,
+          partSize: 100 * 1024 * 1024
         },
         stores: {
           user_files: 'sl_user_files'

--- a/test/unit/js/S3PersistorTests.js
+++ b/test/unit/js/S3PersistorTests.js
@@ -460,6 +460,12 @@ describe('S3PersistorTests', function() {
         })
       })
 
+      it('should upload files in a single part', function() {
+        expect(S3Client.upload).to.have.been.calledWith(sinon.match.any, {
+          partSize: 100 * 1024 * 1024
+        })
+      })
+
       it('should meter the stream', function() {
         expect(Stream.pipeline).to.have.been.calledWith(
           ReadStream,


### PR DESCRIPTION
### Description

When uploading a file, we verify the md5 based on the eTag. By default, `upload` will use a multipart upload if the file is over 5MiB.

When using a multipart upload, the md5 hash is not correctly calcuated, and is returned in a different format.

This PR:

- sets the max chunk size to 100MiB, to ensure files are uploaded in a single part
- fetches the file to calculate the md5 in the case where the md5 is not in the correct format

The latter should fix issues where we need to calculate the md5 hash of a file stored in S3 which has been uploaded as a multipart upload. This shouldn't need to happen very often.

### Review

Without setting the chunk size, this could cause a lot of additional ingress as we would be re-downloading any >5MiB file. However, in pretty much every case we should be uploading in a single part, in which case the eTag will be the md5 hash.

#### Potential Impact

S3 uploads

#### Manual Testing Performed

- [ ] Upload a file bigger than 5MiB

#### Metrics and Monitoring

We should keep track of the `s3.ingress` and `s3.egress` metrics, to verify that this does not have a significant impact on bandwidth.