### PR TITLE
[misc] test cleanup

### DIFF
--- a/test/acceptance/js/FilestoreApp.js
+++ b/test/acceptance/js/FilestoreApp.js
@@ -62,6 +62,7 @@ class FilestoreApp {
   }
 
   async stop() {
+    if (!this.server) return
     const closeServer = promisify(this.server.close).bind(this.server)
     try {
       await closeServer()

--- a/test/acceptance/js/FilestoreTests.js
+++ b/test/acceptance/js/FilestoreTests.js
@@ -415,8 +415,8 @@ describe('Filestore', function() {
 
             const s3ClientSettings = {
               credentials: {
-                accessKeyId: 'fake',
-                secretAccessKey: 'fake'
+                accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+                secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
               },
               endpoint: process.env.AWS_S3_ENDPOINT,
               sslEnabled: false,

--- a/test/unit/js/ImageOptimiserTests.js
+++ b/test/unit/js/ImageOptimiserTests.js
@@ -19,7 +19,10 @@ describe('ImageOptimiser', function() {
     ImageOptimiser = SandboxedModule.require(modulePath, {
       requires: {
         './SafeExec': SafeExec,
-        'logger-sharelatex': logger
+        'logger-sharelatex': logger,
+        'metrics-sharelatex': {
+          Timer: sinon.stub().returns({ done: sinon.stub() })
+        }
       }
     })
   })

--- a/test/unit/js/KeybuilderTests.js
+++ b/test/unit/js/KeybuilderTests.js
@@ -2,7 +2,7 @@ const SandboxedModule = require('sandboxed-module')
 
 const modulePath = '../../../app/js/KeyBuilder.js'
 
-describe('LocalFileWriter', function() {
+describe('KeybuilderTests', function() {
   let KeyBuilder
   const key = 'wombat/potato'
 

--- a/test/unit/js/KeybuilderTests.js
+++ b/test/unit/js/KeybuilderTests.js
@@ -7,7 +7,9 @@ describe('LocalFileWriter', function() {
   const key = 'wombat/potato'
 
   beforeEach(function() {
-    KeyBuilder = SandboxedModule.require(modulePath)
+    KeyBuilder = SandboxedModule.require(modulePath, {
+      requires: { 'settings-sharelatex': {} }
+    })
   })
 
   describe('cachedKey', function() {

--- a/test/unit/js/S3PersistorTests.js
+++ b/test/unit/js/S3PersistorTests.js
@@ -158,7 +158,7 @@ describe('S3PersistorTests', function() {
         'metrics-sharelatex': Metrics,
         crypto
       },
-      globals: { console }
+      globals: { console, Buffer }
     })
   })
 

--- a/test/unit/js/SafeExecTests.js
+++ b/test/unit/js/SafeExecTests.js
@@ -12,6 +12,7 @@ describe('SafeExec', function() {
     options = { timeout: 10 * 1000, killSignal: 'SIGTERM' }
 
     safeExec = SandboxedModule.require(modulePath, {
+      globals: { process },
       requires: {
         'settings-sharelatex': settings
       }


### PR DESCRIPTION
### Description

These are all rather unrelated patches -- they all touch tests. So I recommend reviewing them on a per-commit basis. 

### Review

- [misc] test/unit: add missing require stubs for metrics and settings f0c8eac

  less verbose tests and slightly better performance due to omitted imports

- [misc] test/unit: add missing globals that are lazy loaded 2300727
  
  preparation for node 12

- [misc] test/unit: KeybuilderTests: use a unique suite label 3b7e33a

  fix copy and paste error. useful for limiting the number of running test suites via `MOCHA_GREP`

- [misc] test/acceptance: harden the startup check for s3 57edd4b

  minio -- my s3 replacement -- returns a 403 without auth, failing the current startup check. Placing a file in s3 as the startup check functions as an extended healthcheck too. Also limits the timeout to the one of the test-suite and returns a descriptive error just before hitting the timeout.

- [misc] test/acceptance: skip the shutdown in case we did not start yet 2e3cb96

  otherwise there are errors from cleanup when the startup fails.

- [misc] test/acceptance: do not hard code fake credentials 480470f

  pickup auth from env vars instead -- useful when there are actual credentials required, e.g. for minio.

- [misc] test/acceptance: retrieve ingress metrics just before using it d831a31

  The upload request can bump the ingress metric.
  The content hash validation might require a full download
  in case the ETag field of the upload response is not a md5 sum.


#### Potential Impact
Low, only test files are touched.

