### PR TITLE
Fix prettier task

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 // this file was auto-generated, do not edit it directly.
 // instead run bin/update_build_scripts from
 // https://github.com/sharelatex/sharelatex-dev-environment
-// Version: 1.3.5
+// Version: 1.3.6
 {
   "extends": [
     "standard",

--- a/.eslintrc
+++ b/.eslintrc
@@ -23,8 +23,7 @@
   "rules": {
     // Swap the no-unused-expressions rule with a more chai-friendly one
     "no-unused-expressions": 0,
-    "chai-friendly/no-unused-expressions": "error",
-    "no-console": "error"
+    "chai-friendly/no-unused-expressions": "error"
   },
   "overrides": [
     {

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.3.5
+# Version: 1.3.6
 {
   "semi": false,
   "singleQuote": true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.3.5
+# Version: 1.3.6
 
 FROM node:10.19.0 as base
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.3.5
+# Version: 1.3.6
 
 BUILD_NUMBER ?= local
 BRANCH_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)

--- a/buildscript.txt
+++ b/buildscript.txt
@@ -8,4 +8,4 @@ filestore
 --docker-repos=gcr.io/overleaf-ops
 --env-pass-through=
 --data-dirs=uploads,user_files,template_files
---script-version=1.3.5
+--script-version=1.3.6

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,7 +1,7 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.3.5
+# Version: 1.3.6
 
 version: "2.3"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.3.5
+# Version: 1.3.6
 
 version: "2.3"
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "start": "node $NODE_APP_OPTIONS app.js",
     "nodemon": "nodemon --config nodemon.json",
     "lint": "node_modules/.bin/eslint .",
-    "format": "node_modules/.bin/prettier-eslint '**/*.js' --list-different",
-    "format:fix": "node_modules/.bin/prettier-eslint '**/*.js' --write",
+    "format": "node_modules/.bin/prettier-eslint $PWD'/**/*.js' --list-different",
+    "format:fix": "node_modules/.bin/prettier-eslint $PWD'/**/*.js' --write",
     "test:acceptance:_run": "mocha --recursive --reporter spec --timeout 15000 --exit $@ test/acceptance/js",
     "test:unit:_run": "mocha --recursive --reporter spec $@ test/unit/js"
   },


### PR DESCRIPTION
# Description

The latest version of Prettier wants to be run with a full path instead of a relative one. This change calls Prettier with `$PWD` prepended to the path.

#### Related Issues / PRs

Introduced in #99 

### Review

Fix from https://stackoverflow.com/questions/60103564/there-was-trouble-creating-the-eslint-cliengine
