### PR TITLE
Fix fallback to custom s3 buckets

### DIFF
--- a/app/js/MigrationPersistor.js
+++ b/app/js/MigrationPersistor.js
@@ -115,7 +115,7 @@ module.exports = function(primary, fallback) {
   }
 
   function _getFallbackBucket(bucket) {
-    return Settings.filestore.fallback.buckets[bucket]
+    return Settings.filestore.fallback.buckets[bucket] || bucket
   }
 
   function _wrapFallbackMethod(method) {

--- a/test/acceptance/js/FilestoreTests.js
+++ b/test/acceptance/js/FilestoreTests.js
@@ -374,7 +374,7 @@ describe('Filestore', function() {
         })
       })
 
-      if (backend === 'S3Persistor') {
+      if (backend === 'S3Persistor' || backend === 'FallbackGcsToS3Persistor') {
         describe('with a file in a specific bucket', function() {
           let constantFileContent, fileId, fileUrl, bucketName
 


### PR DESCRIPTION
### Description

Falling back to S3 custom buckets (e.g. for latexqc) was not working, as the fallback bucket would be null if not defined in the settings.

We should pass through the bucket instead of returning nothing, if we don't have a fallback for it. The worst that could happen is a 4xx error.

#### Review

I've tested this on staging. Properly this time.

I made the change to the tests first, and they failed until I added the fix to `MigrationPersistor.js`