### PR TITLE
Use single pipeline when calculating md5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5382,14 +5382,6 @@
         "stubs": "^3.0.0"
       }
     },
-    "stream-meter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/stream-meter/-/stream-meter-1.0.4.tgz",
-      "integrity": "sha512-4sOEtrbgFotXwnEuzzsQBYEV1elAeFSO8rSGeTwabuX1RRn/kEq9JVH7I0MRBhKVRR0sJkr0M0QCH7yOLf9fhQ==",
-      "requires": {
-        "readable-stream": "^2.1.4"
-      }
-    },
     "stream-shift": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "request-promise-native": "^1.0.8",
     "settings-sharelatex": "^1.1.0",
     "stream-buffers": "~0.2.5",
-    "stream-meter": "^1.0.4",
     "tiny-async-pool": "^1.1.0"
   },
   "devDependencies": {

--- a/test/unit/js/FSPersistorTests.js
+++ b/test/unit/js/FSPersistorTests.js
@@ -3,6 +3,7 @@ const chai = require('chai')
 const { expect } = chai
 const SandboxedModule = require('sandboxed-module')
 const Errors = require('../../../app/js/Errors')
+const StreamModule = require('stream')
 
 chai.use(require('sinon-chai'))
 chai.use(require('chai-as-promised'))
@@ -38,7 +39,10 @@ describe('FSPersistorTests', function() {
       stat: sinon.stub().yields(null, stat)
     }
     glob = sinon.stub().yields(null, globs)
-    stream = { pipeline: sinon.stub().yields() }
+    stream = {
+      pipeline: sinon.stub().yields(),
+      Transform: StreamModule.Transform
+    }
     LocalFileWriter = {
       promises: {
         writeStream: sinon.stub().resolves(tempFile),
@@ -48,6 +52,7 @@ describe('FSPersistorTests', function() {
     Hash = {
       end: sinon.stub(),
       read: sinon.stub().returns(md5),
+      digest: sinon.stub().returns(md5),
       setEncoding: sinon.stub()
     }
     crypto = {
@@ -62,7 +67,6 @@ describe('FSPersistorTests', function() {
         stream,
         crypto,
         // imported by PersistorHelper but otherwise unused here
-        'stream-meter': {},
         'logger-sharelatex': {},
         'metrics-sharelatex': {}
       },


### PR DESCRIPTION
### Description

Adds a new `Stream.Transform` class that calculates the hash *and* byte count of a stream and passes it through. This removes the need for a separate metered stream module.

The idea here is that we have one single pipeline, instead if splitting the incoming data into two.

### Review

I've left in the `calculateStreamMd5` method, as this is called from the MD5-calculation endpoint and is useful when we want an MD5 but don't want to pass the stream through to anything else.

The dependency on `stream-meter` has been removed.

I've removed a couple of unit tests about egress/ingress metrics, as these were faffy to implement. I think there is very good acceptance-test coverage here, so I don't think that this is a problem.

#### Potential Impact

Most things.
