### PR TITLE
(Hopefully) fix handle leaks

### DIFF
--- a/app/js/GcsPersistor.js
+++ b/app/js/GcsPersistor.js
@@ -126,10 +126,10 @@ async function getFileStream(bucketName, key, _opts = {}) {
   const observer = new PersistorHelper.ObserverStream({
     metric: 'gcs.ingress'
   })
-  pipeline(stream, observer)
 
   try {
-    await PersistorHelper.waitForStreamReady(stream)
+    // wait for the pipeline to be ready, to catch non-200s
+    await PersistorHelper.getReadyPipeline(stream, observer)
     return observer
   } catch (err) {
     throw PersistorHelper.wrapError(

--- a/app/js/PersistorHelper.js
+++ b/app/js/PersistorHelper.js
@@ -15,6 +15,7 @@ const pipeline = promisify(Stream.pipeline)
 //   the number of bytes transferred
 class ObserverStream extends Stream.Transform {
   constructor(options) {
+    options.autoDestroy = true
     super(options)
 
     this.bytes = 0

--- a/app/js/S3Persistor.js
+++ b/app/js/S3Persistor.js
@@ -131,10 +131,10 @@ async function getFileStream(bucketName, key, opts) {
 
   // ingress from S3 to us
   const observer = new PersistorHelper.ObserverStream({ metric: 's3.ingress' })
-  pipeline(stream, observer)
 
   try {
-    await PersistorHelper.waitForStreamReady(stream)
+    // wait for the pipeline to be ready, to catch non-200s
+    await PersistorHelper.getReadyPipeline(stream, observer)
     return observer
   } catch (err) {
     throw PersistorHelper.wrapError(

--- a/test/acceptance/js/FilestoreTests.js
+++ b/test/acceptance/js/FilestoreTests.js
@@ -27,7 +27,7 @@ if (!process.env.AWS_ACCESS_KEY_ID) {
 }
 
 process.on('unhandledRejection', e => {
-  // eslint-disable no-console
+  // eslint-disable-next-line no-console
   console.log('** Unhandled Promise Rejection **\n', e)
   throw e
 })

--- a/test/acceptance/js/FilestoreTests.js
+++ b/test/acceptance/js/FilestoreTests.js
@@ -26,6 +26,12 @@ if (!process.env.AWS_ACCESS_KEY_ID) {
   throw new Error('please provide credentials for the AWS S3 test server')
 }
 
+process.on('unhandledRejection', e => {
+  // eslint-disable no-console
+  console.log('** Unhandled Promise Rejection **\n', e)
+  throw e
+})
+
 // store settings for multiple backends, so that we can test each one.
 // fs will always be available - add others if they are configured
 const BackendSettings = require('./TestConfig')

--- a/test/unit/js/GcsPersistorTests.js
+++ b/test/unit/js/GcsPersistorTests.js
@@ -202,7 +202,7 @@ describe('GcsPersistorTests', function() {
 
       beforeEach(async function() {
         Transform.prototype.on = sinon.stub()
-        Transform.prototype.on.withArgs('error').yields(GcsNotFoundError)
+        Stream.pipeline.yields(GcsNotFoundError)
         try {
           stream = await GcsPersistor.promises.getFileStream(bucket, key)
         } catch (err) {
@@ -232,7 +232,7 @@ describe('GcsPersistorTests', function() {
 
       beforeEach(async function() {
         Transform.prototype.on = sinon.stub()
-        Transform.prototype.on.withArgs('error').yields(genericError)
+        Stream.pipeline.yields(genericError)
         try {
           stream = await GcsPersistor.promises.getFileStream(bucket, key)
         } catch (err) {

--- a/test/unit/js/GcsPersistorTests.js
+++ b/test/unit/js/GcsPersistorTests.js
@@ -5,7 +5,6 @@ const modulePath = '../../../app/js/GcsPersistor.js'
 const SandboxedModule = require('sandboxed-module')
 const { ObjectId } = require('mongodb')
 const asyncPool = require('tiny-async-pool')
-const StreamModule = require('stream')
 
 const Errors = require('../../../app/js/Errors')
 
@@ -21,6 +20,7 @@ describe('GcsPersistorTests', function() {
 
   let Metrics,
     Logger,
+    Transform,
     Storage,
     Fs,
     GcsNotFoundError,
@@ -68,9 +68,20 @@ describe('GcsPersistorTests', function() {
       removeListener: sinon.stub()
     }
 
+    Transform = class {
+      on(event, callback) {
+        if (event === 'readable') {
+          callback()
+        }
+      }
+
+      once() {}
+      removeListener() {}
+    }
+
     Stream = {
       pipeline: sinon.stub().yields(),
-      Transform: StreamModule.Transform
+      Transform: Transform
     }
 
     Metrics = {
@@ -147,7 +158,7 @@ describe('GcsPersistorTests', function() {
       })
 
       it('returns a metered stream', function() {
-        expect(stream).to.be.instanceOf(StreamModule.Transform)
+        expect(stream).to.be.instanceOf(Transform)
       })
 
       it('fetches the right key from the right bucket', function() {
@@ -159,7 +170,7 @@ describe('GcsPersistorTests', function() {
       it('pipes the stream through the meter', function() {
         expect(Stream.pipeline).to.have.been.calledWith(
           ReadStream,
-          sinon.match.instanceOf(StreamModule.Transform)
+          sinon.match.instanceOf(Transform)
         )
       })
     })
@@ -175,7 +186,7 @@ describe('GcsPersistorTests', function() {
       })
 
       it('returns a metered stream', function() {
-        expect(stream).to.be.instanceOf(StreamModule.Transform)
+        expect(stream).to.be.instanceOf(Transform)
       })
 
       it('passes the byte range on to GCS', function() {
@@ -190,8 +201,8 @@ describe('GcsPersistorTests', function() {
       let error, stream
 
       beforeEach(async function() {
-        ReadStream.on = sinon.stub()
-        ReadStream.on.withArgs('error').yields(GcsNotFoundError)
+        Transform.prototype.on = sinon.stub()
+        Transform.prototype.on.withArgs('error').yields(GcsNotFoundError)
         try {
           stream = await GcsPersistor.promises.getFileStream(bucket, key)
         } catch (err) {
@@ -220,8 +231,8 @@ describe('GcsPersistorTests', function() {
       let error, stream
 
       beforeEach(async function() {
-        ReadStream.on = sinon.stub()
-        ReadStream.on.withArgs('error').yields(genericError)
+        Transform.prototype.on = sinon.stub()
+        Transform.prototype.on.withArgs('error').yields(genericError)
         try {
           stream = await GcsPersistor.promises.getFileStream(bucket, key)
         } catch (err) {
@@ -330,7 +341,7 @@ describe('GcsPersistorTests', function() {
       it('should meter the stream and pass it to GCS', function() {
         expect(Stream.pipeline).to.have.been.calledWith(
           ReadStream,
-          sinon.match.instanceOf(StreamModule.Transform),
+          sinon.match.instanceOf(Transform),
           WriteStream
         )
       })
@@ -375,7 +386,7 @@ describe('GcsPersistorTests', function() {
         Stream.pipeline
           .withArgs(
             ReadStream,
-            sinon.match.instanceOf(StreamModule.Transform),
+            sinon.match.instanceOf(Transform),
             WriteStream,
             sinon.match.any
           )
@@ -416,7 +427,7 @@ describe('GcsPersistorTests', function() {
       it('should upload the stream via the meter', function() {
         expect(Stream.pipeline).to.have.been.calledWith(
           ReadStream,
-          sinon.match.instanceOf(StreamModule.Transform),
+          sinon.match.instanceOf(Transform),
           WriteStream
         )
       })

--- a/test/unit/js/S3PersistorTests.js
+++ b/test/unit/js/S3PersistorTests.js
@@ -292,7 +292,7 @@ describe('S3PersistorTests', function() {
 
       beforeEach(async function() {
         Transform.prototype.on = sinon.stub()
-        Transform.prototype.on.withArgs('error').yields(S3NotFoundError)
+        Stream.pipeline.yields(S3NotFoundError)
         try {
           stream = await S3Persistor.promises.getFileStream(bucket, key)
         } catch (err) {
@@ -322,7 +322,7 @@ describe('S3PersistorTests', function() {
 
       beforeEach(async function() {
         Transform.prototype.on = sinon.stub()
-        Transform.prototype.on.withArgs('error').yields(S3AccessDeniedError)
+        Stream.pipeline.yields(S3AccessDeniedError)
         try {
           stream = await S3Persistor.promises.getFileStream(bucket, key)
         } catch (err) {
@@ -352,7 +352,7 @@ describe('S3PersistorTests', function() {
 
       beforeEach(async function() {
         Transform.prototype.on = sinon.stub()
-        Transform.prototype.on.withArgs('error').yields(genericError)
+        Stream.pipeline.yields(genericError)
         try {
           stream = await S3Persistor.promises.getFileStream(bucket, key)
         } catch (err) {

--- a/test/unit/js/S3PersistorTests.js
+++ b/test/unit/js/S3PersistorTests.js
@@ -3,7 +3,6 @@ const chai = require('chai')
 const { expect } = chai
 const modulePath = '../../../app/js/S3Persistor.js'
 const SandboxedModule = require('sandboxed-module')
-const StreamModule = require('stream')
 
 const Errors = require('../../../app/js/Errors')
 
@@ -31,6 +30,7 @@ describe('S3PersistorTests', function() {
 
   let Metrics,
     Logger,
+    Transform,
     S3,
     Fs,
     ReadStream,
@@ -61,9 +61,20 @@ describe('S3PersistorTests', function() {
       }
     }
 
+    Transform = class {
+      on(event, callback) {
+        if (event === 'readable') {
+          callback()
+        }
+      }
+
+      once() {}
+      removeListener() {}
+    }
+
     Stream = {
       pipeline: sinon.stub().yields(),
-      Transform: StreamModule.Transform
+      Transform: Transform
     }
 
     EmptyPromise = {
@@ -100,7 +111,6 @@ describe('S3PersistorTests', function() {
       pipe: sinon.stub(),
       removeListener: sinon.stub()
     }
-    S3ReadStream.on.withArgs('readable').yields()
     S3Client = {
       getObject: sinon.stub().returns({
         createReadStream: sinon.stub().returns(S3ReadStream)
@@ -163,7 +173,7 @@ describe('S3PersistorTests', function() {
       })
 
       it('returns a metered stream', function() {
-        expect(stream).to.be.instanceOf(StreamModule.Transform)
+        expect(stream).to.be.instanceOf(Transform)
       })
 
       it('sets the AWS client up with credentials from settings', function() {
@@ -180,7 +190,7 @@ describe('S3PersistorTests', function() {
       it('pipes the stream through the meter', function() {
         expect(Stream.pipeline).to.have.been.calledWith(
           S3ReadStream,
-          sinon.match.instanceOf(StreamModule.Transform)
+          sinon.match.instanceOf(Transform)
         )
       })
     })
@@ -281,8 +291,8 @@ describe('S3PersistorTests', function() {
       let error, stream
 
       beforeEach(async function() {
-        S3ReadStream.on = sinon.stub()
-        S3ReadStream.on.withArgs('error').yields(S3NotFoundError)
+        Transform.prototype.on = sinon.stub()
+        Transform.prototype.on.withArgs('error').yields(S3NotFoundError)
         try {
           stream = await S3Persistor.promises.getFileStream(bucket, key)
         } catch (err) {
@@ -311,8 +321,8 @@ describe('S3PersistorTests', function() {
       let error, stream
 
       beforeEach(async function() {
-        S3ReadStream.on = sinon.stub()
-        S3ReadStream.on.withArgs('error').yields(S3AccessDeniedError)
+        Transform.prototype.on = sinon.stub()
+        Transform.prototype.on.withArgs('error').yields(S3AccessDeniedError)
         try {
           stream = await S3Persistor.promises.getFileStream(bucket, key)
         } catch (err) {
@@ -341,8 +351,8 @@ describe('S3PersistorTests', function() {
       let error, stream
 
       beforeEach(async function() {
-        S3ReadStream.on = sinon.stub()
-        S3ReadStream.on.withArgs('error').yields(genericError)
+        Transform.prototype.on = sinon.stub()
+        Transform.prototype.on.withArgs('error').yields(genericError)
         try {
           stream = await S3Persistor.promises.getFileStream(bucket, key)
         } catch (err) {
@@ -485,7 +495,7 @@ describe('S3PersistorTests', function() {
         expect(S3Client.upload).to.have.been.calledWith({
           Bucket: bucket,
           Key: key,
-          Body: sinon.match.instanceOf(StreamModule.Transform),
+          Body: sinon.match.instanceOf(Transform),
           ContentMD5: 'qqqqqru7u7uqqqqqu7u7uw=='
         })
       })
@@ -560,7 +570,7 @@ describe('S3PersistorTests', function() {
         expect(S3Client.upload).to.have.been.calledWith({
           Bucket: bucket,
           Key: key,
-          Body: sinon.match.instanceOf(StreamModule.Transform)
+          Body: sinon.match.instanceOf(Transform)
         })
       })
     })


### PR DESCRIPTION
### Description

Try to fix handle leaks.

The most significant thing here was adding https://github.com/overleaf/filestore/commit/04c41816fe690155f325d9024ee11516533b4326 - which fails acceptance tests on unhandled promise rejection. This pointed out unhandled errors from the `pipeline` method when waiting for streams to become readable, which are fixed in https://github.com/overleaf/filestore/commit/d6170c95ee6e2520ad834b133d48cf45a022d9ae

For belt and braces, we also use autodestroy on the transform stream: https://github.com/overleaf/filestore/commit/cab1e3c21e0bc1129f52fdafc58914cf3b352cd1
And pass errors to the `destroy` method in the error handler: https://github.com/overleaf/filestore/commit/f4d08b73c195042cf93f7ac791c3a0932646c1ae

I don't know if either of these will make a difference, but they can't hurt.

### Review

This exposes a subtle misunderstanding in my knowledge of `pipeline`. Specifically, I had a mental model of it looking like this:

```
stream A  === data and errors ===> stream B === data and errors ===> stream C === errors ===> caught by pipeline
```
where it really works like
```
stream A === data ===> stream B === data ===> stream C
   |                      |                      |
   \/                    \/                     \/
pipeline                pipeline              pipeline
```

meaning that you can't expect the last stream in the pipe to emit an error event just because an earlier one does... You need to listen to the `pipeline` itself.
