### PR TITLE
Retry file reads on 5xx error from upstream

### DIFF
--- a/app/js/Errors.js
+++ b/app/js/Errors.js
@@ -26,6 +26,7 @@ class ConversionError extends BackwardCompatibleError {}
 class SettingsError extends BackwardCompatibleError {}
 class TimeoutError extends BackwardCompatibleError {}
 class InvalidParametersError extends BackwardCompatibleError {}
+class UpstreamError extends BackwardCompatibleError {}
 
 class FailedCommandError extends OError {
   constructor(command, code, stdout, stderr) {
@@ -52,5 +53,6 @@ module.exports = {
   HealthCheckError,
   SettingsError,
   TimeoutError,
-  InvalidParametersError
+  InvalidParametersError,
+  UpstreamError
 }

--- a/app/js/FileHandler.js
+++ b/app/js/FileHandler.js
@@ -204,7 +204,7 @@ async function _wrapWithRetry(method, ...params) {
       return result
     } catch (err) {
       if (OError.hasCauseInstanceOf(err, UpstreamError) && tries < maxTries) {
-        await sleep(delay)
+        await sleep(delay * (Math.random() + 0.5))
         tries++
         delay *= 2
       } else {

--- a/app/js/PersistorHelper.js
+++ b/app/js/PersistorHelper.js
@@ -142,7 +142,7 @@ function wrapError(error, message, params, ErrorType) {
     (error.message && error.message.match(/^Cannot parse response as JSON.*/))
   ) {
     return new UpstreamError({
-      message: 'internal error from GCS',
+      message: 'internal error from upstream storage',
       info: params
     }).withCause(error)
   } else {


### PR DESCRIPTION
### Description

We've noticed a number of `502` and `504` errors in the logs - particularly from `filestore-readonly`, which fails the download immediately, possibly breaking a compile in the process.

This patch causes us to retry a few times if we get these errors. They seem very transient so I suspect that retrying will help.

### Review

This only affects `getFoo`, and only when the download fails the first time and we would have thrown an error anyway... So I think it's fairly safe to try.

I couldn't make an acceptance test for this against the fake GCS server, so the unit tests will have to do.

#### Potential Impact

Downloading files, when errors occur
