### PR TITLE
Call end() when handing ERR_STREAM_PREMATURE_CLOSE

### DIFF
--- a/app/js/FileController.js
+++ b/app/js/FileController.js
@@ -61,18 +61,18 @@ function getFile(req, res, next) {
     }
 
     pipeline(fileStream, res, err => {
-      if (err) {
+      if (!fileStream.destroyed) {
         fileStream.destroy()
-        if (err.code === 'ERR_STREAM_PREMATURE_CLOSE') {
-          res.end()
-        } else {
-          next(
-            new Errors.ReadError({
-              message: 'error transferring stream',
-              info: { bucket, key, format, style }
-            }).withCause(err)
-          )
-        }
+      }
+      if (err && err.code === 'ERR_STREAM_PREMATURE_CLOSE') {
+        res.end()
+      } else if (err) {
+        next(
+          new Errors.ReadError({
+            message: 'error transferring stream',
+            info: { bucket, key, format, style }
+          }).withCause(err)
+        )
       }
     })
   })

--- a/app/js/FileController.js
+++ b/app/js/FileController.js
@@ -61,7 +61,9 @@ function getFile(req, res, next) {
     }
 
     pipeline(fileStream, res, err => {
-      if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
+      if (err && err.code === 'ERR_STREAM_PREMATURE_CLOSE') {
+        res.end()
+      } else if (err) {
         next(
           new Errors.ReadError({
             message: 'error transferring stream',

--- a/app/js/FileController.js
+++ b/app/js/FileController.js
@@ -61,15 +61,18 @@ function getFile(req, res, next) {
     }
 
     pipeline(fileStream, res, err => {
-      if (err && err.code === 'ERR_STREAM_PREMATURE_CLOSE') {
-        res.end()
-      } else if (err) {
-        next(
-          new Errors.ReadError({
-            message: 'error transferring stream',
-            info: { bucket, key, format, style }
-          }).withCause(err)
-        )
+      if (err) {
+        fileStream.destroy()
+        if (err.code === 'ERR_STREAM_PREMATURE_CLOSE') {
+          res.end()
+        } else {
+          next(
+            new Errors.ReadError({
+              message: 'error transferring stream',
+              info: { bucket, key, format, style }
+            }).withCause(err)
+          )
+        }
       }
     })
   })

--- a/app/js/PersistorHelper.js
+++ b/app/js/PersistorHelper.js
@@ -112,6 +112,11 @@ function getReadyPipeline(...streams) {
         }
         resolve(lastStream)
       }
+      if (err) {
+        for (const stream of streams) {
+          stream.destroy()
+        }
+      }
     }
 
     pipeline(...streams).catch(handler)

--- a/app/js/PersistorHelper.js
+++ b/app/js/PersistorHelper.js
@@ -114,7 +114,9 @@ function getReadyPipeline(...streams) {
       }
       if (err) {
         for (const stream of streams) {
-          stream.destroy()
+          if (!stream.destroyed) {
+            stream.destroy()
+          }
         }
       }
     }


### PR DESCRIPTION
### Description

It looks like we are not doing anything on an `ERR_STREAM_PREMATURE_CLOSE` error. I think this was an attempt to not write errors to the logs when this happens.

On other errors, we are passing on to `next`. On no error, I would assume that the request has completed successfully. This patch tries to close the connection when a premature-close error occurs, rather than leaving it hanging.

See further diagnosis at: https://github.com/overleaf/issues/issues/2880#issuecomment-606033804