### PR TITLE
Only delete the converted-cache folder if conversions are enabled

### DIFF
--- a/app/js/FileHandler.js
+++ b/app/js/FileHandler.js
@@ -51,7 +51,7 @@ async function deleteFile(bucket, key) {
   if (Settings.enableConversions) {
     jobs.push(PersistorManager.promises.deleteDirectory(bucket, convertedKey))
   }
-  await Promise.all([jobs])
+  await Promise.all(jobs)
 }
 
 async function deleteProject(bucket, key) {


### PR DESCRIPTION
### Description

Don't call `deleteDirectory` on the `converted-cache` folder when inserting or deleting files, unless conversions are enabled.

Slack discussion: https://digital-science.slack.com/archives/G6256GXGS/p1585663651303300

#### Review

It's highly probable that we don't need to delete the directory on `insertFile` based on how we expect uploads to work, but I would rather change as little as possible so I'm leaving this in place for now.