### PR TITLE
Destroy download streams on close

### DIFF
--- a/app/js/PersistorHelper.js
+++ b/app/js/PersistorHelper.js
@@ -106,11 +106,12 @@ function getReadyPipeline(...streams) {
 
         lastStream.removeListener('readable', handler)
         if (err) {
-          return reject(
+          reject(
             wrapError(err, 'error before stream became ready', {}, ReadError)
           )
+        } else {
+          resolve(lastStream)
         }
-        resolve(lastStream)
       }
       if (err) {
         for (const stream of streams) {
@@ -121,6 +122,9 @@ function getReadyPipeline(...streams) {
       }
     }
 
+    for (let index = 0; index < streams.length - 1; index++) {
+      streams[index + 1].on('close', () => streams[index].destroy())
+    }
     pipeline(...streams).catch(handler)
     lastStream.on('readable', handler)
   })


### PR DESCRIPTION
### Description

This modifies the `getReadyPipeline` helper to do two things:

* Ensures that streams are destroyed on error, when the error is caught before the promise rejects
* Calls `destroy` on streams in the pipeline when the next one emits `close`

### Review

I realise that this is throwing stuff at the wall to see what sticks somewhat, but here we are.
