### PR TITLE
Ensure streams are drained when a pipeline fails

### DIFF
--- a/app/js/FileController.js
+++ b/app/js/FileController.js
@@ -61,9 +61,6 @@ function getFile(req, res, next) {
     }
 
     pipeline(fileStream, res, err => {
-      if (!fileStream.destroyed) {
-        fileStream.destroy()
-      }
       if (err && err.code === 'ERR_STREAM_PREMATURE_CLOSE') {
         res.end()
       } else if (err) {


### PR DESCRIPTION
### Description

Adds an acceptance test to look for socket leaks, and then modifies the pipeline mechanism to ensure that it passes.

The modifications to the mechanism avoid the use of `pipeline` which can cause problems in this particular situation.

#### Related Issues / PRs

Fixes overleaf/issues#2880 (I hope!)

### Review

Took some time this one because `pipeline` is supposed to do this.

Some points worth noting:
* The acceptance test fails in the same way as it does on production, in that the leaked sockets look the same (recv queue but no send queue)
* The acceptance test fails for S3 and GCS in the same way, which is potentially a source of earlier confusion
* Passing back the stream returned from `GCS.bucket.file.createReadStream` directly to `FileController` *does not* fix the problem

I spent some time watching events on a debugger. Here is what happens:
1. `res` express stream emits `close`
1. `ObserverStream` emits close
1. GCS stream emits close (but the socket hangs)
1. `pipeline` emits an `ERR_STREAM_PREMATURE_CLOSE` error

At the point that we receive the error, the GCS (or S3) stream has already `close`d and `destroy`ed. You can't `resume` it because it's already dead, and re-`destroy`ing it does nothing. The socket still exists. In order to successfully clear the socket we need to drain its contents, but we can't do this now because as far as Node is concerned it's already dead.

For this to work, we need to:

1. Unpipe the stream, as the stream it is piping into has been destroyed
1. Resume the stream into the bitbucket

#### Also of note

This used to work! So, I'm not entirely sure what changed. However we have seen:

* significant framework re-architecturing
* node upgrades (to 12, which is higher than most other things)
* package upgrades (e.g. express was upgraded a long way)

We certainly weren't leaking handles before we did a lot of the recent work or we would have noticed. Which is odd, but not impossible given the above.

#### Potential Impact

Downloading files, resource usage.
