### PR TITLE
Fix error handler returning two responses

### DIFF
--- a/app/js/RequestLogger.js
+++ b/app/js/RequestLogger.js
@@ -17,10 +17,7 @@ class RequestLogger {
 
   static errorHandler(err, req, res, next) {
     req.requestLogger.addFields({ error: err })
-    res
-      .send(err.message)
-      .status(500)
-      .end()
+    res.status(500).send(err.message)
   }
 
   static middleware(req, res, next) {


### PR DESCRIPTION
### Description

The error handler mistakenly sent two responses on error, the first
being a 200.

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2925

### Review



#### Potential Impact

Everything related to file storage.

#### Manual Testing Performed

- [x] Upload a file with GCS turned off. Upload fails