### PR TITLE
Add support for redirecting to signed URLs

### DIFF
--- a/app/js/FSPersistor.js
+++ b/app/js/FSPersistor.js
@@ -74,6 +74,11 @@ async function getFileStream(location, name, opts) {
   return fs.createReadStream(null, opts)
 }
 
+async function getRedirectUrl() {
+  // not implemented
+  return null
+}
+
 async function getFileSize(location, filename) {
   const fullPath = path.join(location, filterName(filename))
 
@@ -211,6 +216,7 @@ module.exports = {
   sendFile: callbackify(sendFile),
   sendStream: callbackify(sendStream),
   getFileStream: callbackify(getFileStream),
+  getRedirectUrl: callbackify(getRedirectUrl),
   getFileSize: callbackify(getFileSize),
   getFileMd5Hash: callbackify(getFileMd5Hash),
   copyFile: callbackify(copyFile),
@@ -222,6 +228,7 @@ module.exports = {
     sendFile,
     sendStream,
     getFileStream,
+    getRedirectUrl,
     getFileSize,
     getFileMd5Hash,
     copyFile,

--- a/app/js/FileHandler.js
+++ b/app/js/FileHandler.js
@@ -13,10 +13,12 @@ module.exports = {
   deleteFile: callbackify(deleteFile),
   deleteProject: callbackify(deleteProject),
   getFile: callbackify(getFile),
+  getRedirectUrl: callbackify(getRedirectUrl),
   getFileSize: callbackify(getFileSize),
   getDirectorySize: callbackify(getDirectorySize),
   promises: {
     getFile,
+    getRedirectUrl,
     insertFile,
     deleteFile,
     deleteProject,
@@ -71,6 +73,24 @@ async function getFile(bucket, key, opts) {
   } else {
     return _getConvertedFile(bucket, key, opts)
   }
+}
+
+async function getRedirectUrl(bucket, key, opts) {
+  // if we're doing anything unusual with options, or the request isn't for
+  // one of the default buckets, return null so that we proxy the file
+  opts = opts || {}
+  if (
+    !opts.start &&
+    !opts.end &&
+    !opts.format &&
+    !opts.style &&
+    Object.values(Settings.filestore.stores).includes(bucket) &&
+    Settings.filestore.allowRedirects
+  ) {
+    return PersistorManager.promises.getRedirectUrl(bucket, key)
+  }
+
+  return null
 }
 
 async function getFileSize(bucket, key) {

--- a/app/js/GcsPersistor.js
+++ b/app/js/GcsPersistor.js
@@ -36,6 +36,7 @@ const GcsPersistor = {
   sendFile: callbackify(sendFile),
   sendStream: callbackify(sendStream),
   getFileStream: callbackify(getFileStream),
+  getRedirectUrl: callbackify(getRedirectUrl),
   getFileMd5Hash: callbackify(getFileMd5Hash),
   deleteDirectory: callbackify(deleteDirectory),
   getFileSize: callbackify(getFileSize),
@@ -47,6 +48,7 @@ const GcsPersistor = {
     sendFile,
     sendStream,
     getFileStream,
+    getRedirectUrl,
     getFileMd5Hash,
     deleteDirectory,
     getFileSize,
@@ -136,6 +138,26 @@ async function getFileStream(bucketName, key, _opts = {}) {
       err,
       'error reading file from GCS',
       { bucketName, key, opts },
+      ReadError
+    )
+  }
+}
+
+async function getRedirectUrl(bucketName, key) {
+  try {
+    const [url] = await storage
+      .bucket(bucketName)
+      .file(key)
+      .getSignedUrl({
+        action: 'read',
+        expires: new Date().getTime() + settings.filestore.signedUrlExpiryInMs
+      })
+    return url
+  } catch (err) {
+    throw PersistorHelper.wrapError(
+      err,
+      'error generating signed url for GCS file',
+      { bucketName, key },
       ReadError
     )
   }

--- a/app/js/MigrationPersistor.js
+++ b/app/js/MigrationPersistor.js
@@ -203,6 +203,7 @@ module.exports = function(primary, fallback) {
     sendFile: primary.sendFile,
     sendStream: primary.sendStream,
     getFileStream: callbackify(getFileStreamWithFallback),
+    getRedirectUrl: primary.getRedirectUrl,
     getFileMd5Hash: callbackify(_wrapFallbackMethod('getFileMd5Hash')),
     deleteDirectory: callbackify(
       _wrapMethodOnBothPersistors('deleteDirectory')
@@ -216,6 +217,7 @@ module.exports = function(primary, fallback) {
       sendFile: primary.promises.sendFile,
       sendStream: primary.promises.sendStream,
       getFileStream: getFileStreamWithFallback,
+      getRedirectUrl: primary.promises.getRedirectUrl,
       getFileMd5Hash: _wrapFallbackMethod('getFileMd5Hash'),
       deleteDirectory: _wrapMethodOnBothPersistors('deleteDirectory'),
       getFileSize: _wrapFallbackMethod('getFileSize'),

--- a/app/js/S3Persistor.js
+++ b/app/js/S3Persistor.js
@@ -24,6 +24,7 @@ const S3Persistor = {
   sendFile: callbackify(sendFile),
   sendStream: callbackify(sendStream),
   getFileStream: callbackify(getFileStream),
+  getRedirectUrl: callbackify(getRedirectUrl),
   getFileMd5Hash: callbackify(getFileMd5Hash),
   deleteDirectory: callbackify(deleteDirectory),
   getFileSize: callbackify(getFileSize),
@@ -35,6 +36,7 @@ const S3Persistor = {
     sendFile,
     sendStream,
     getFileStream,
+    getRedirectUrl,
     getFileMd5Hash,
     deleteDirectory,
     getFileSize,
@@ -144,6 +146,11 @@ async function getFileStream(bucketName, key, opts) {
       ReadError
     )
   }
+}
+
+async function getRedirectUrl() {
+  // not implemented
+  return null
 }
 
 async function deleteDirectory(bucketName, key) {

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -70,6 +70,9 @@ settings =
 				buckets: JSON.parse(process.env['FALLBACK_BUCKET_MAPPING'] || '{}')
 				copyOnMiss: process.env['COPY_ON_MISS'] == 'true'
 
+		allowRedirects: if process.env['ALLOW_REDIRECTS'] == 'true' then true else false
+		signedUrlExpiryInMs: parseInt(process.env['LINK_EXPIRY_TIMEOUT'] || 60000)
+
 	path:
 		uploadFolder: Path.resolve(__dirname + "/../uploads")
 

--- a/test/unit/js/GcsPersistorTests.js
+++ b/test/unit/js/GcsPersistorTests.js
@@ -17,6 +17,7 @@ describe('GcsPersistorTests', function() {
   const filesSize = 33
   const md5 = 'ffffffff00000000ffffffff00000000'
   const WriteStream = 'writeStream'
+  const redirectUrl = 'https://wombat.potato/giraffe'
 
   let Metrics,
     Logger,
@@ -97,7 +98,8 @@ describe('GcsPersistorTests', function() {
       getMetadata: sinon.stub().resolves([files[0].metadata]),
       createWriteStream: sinon.stub().returns(WriteStream),
       copy: sinon.stub().resolves(),
-      exists: sinon.stub().resolves([true])
+      exists: sinon.stub().resolves([true]),
+      getSignedUrl: sinon.stub().resolves([redirectUrl])
     }
 
     GcsBucket = {
@@ -257,6 +259,22 @@ describe('GcsPersistorTests', function() {
       it('stores the bucket and key in the error', function() {
         expect(error.info).to.include({ bucketName: bucket, key: key })
       })
+    })
+  })
+
+  describe('getFile', function() {
+    let signedUrl
+
+    beforeEach(async function() {
+      signedUrl = await GcsPersistor.promises.getRedirectUrl(bucket, key)
+    })
+
+    it('should request a signed URL', function() {
+      expect(GcsFile.getSignedUrl).to.have.been.called
+    })
+
+    it('should return the url', function() {
+      expect(signedUrl).to.equal(redirectUrl)
     })
   })
 


### PR DESCRIPTION
### Description

Add a mechanism to retrieve a signed URL from filestore and redirect to it, instead of proxying the file directly.

Falls back to proxying if the url can't be retrieved.

#### Related Issues / PRs

Fixes overleaf/issues#2937

### Review

I've only added support for redirects to the GCS persistor, as this is where the bulk of the traffic goes. If we're using the S3 persistor now it's because we're falling back to an unusual bucket.

It's running in staging with redirect URLs only enabled for `filestore-readonly`. I think this is sensible for now as that's where the bulk of the load comes from. Compiles still work and I'm seeing hits on the `file_redirect` metric.

I couldn't get acceptance tests working against this, or signed URLs working in dev. Tested in staging.

#### Potential Impact

Requires a settings change to proxy the files - assuming we're just making this change for readonly, this affects compiles.

#### Manual Testing Performed

- [x] Tested compiles in staging with this setting turned on

### Deployment

Requires setting `ALLOW_REDIRECTS: 'true'` for `filestore-readonly`

#### Metrics and Monitoring

There are two new metrics: `file_redirect` and `file_redirect_error` so that we can watch for problems and make sure that it's doing what we want.