### PR TITLE
Fixed regular expression to insert/delete files not supporting templates API

### DIFF
--- a/app/js/FileHandler.js
+++ b/app/js/FileHandler.js
@@ -29,7 +29,7 @@ module.exports = {
 
 async function insertFile(bucket, key, stream) {
   const convertedKey = KeyBuilder.getConvertedFolderKey(key)
-  if (!convertedKey.match(/^[0-9a-f]{24}\/[0-9a-f]{24}/i)) {
+  if (!convertedKey.match(/^[0-9a-f]{24}\/([0-9a-f]{24}|v\/[0-9]+\/[a-z]+)/i)) {
     throw new InvalidParametersError({
       message: 'key does not match validation regex',
       info: { bucket, key, convertedKey }
@@ -43,7 +43,7 @@ async function insertFile(bucket, key, stream) {
 
 async function deleteFile(bucket, key) {
   const convertedKey = KeyBuilder.getConvertedFolderKey(key)
-  if (!convertedKey.match(/^[0-9a-f]{24}\/[0-9a-f]{24}/i)) {
+  if (!convertedKey.match(/^[0-9a-f]{24}\/([0-9a-f]{24}|v\/[0-9]+\/[a-z]+)/i)) {
     throw new InvalidParametersError({
       message: 'key does not match validation regex',
       info: { bucket, key, convertedKey }

--- a/test/unit/js/FileHandlerTests.js
+++ b/test/unit/js/FileHandlerTests.js
@@ -111,6 +111,16 @@ describe('FileHandler', function() {
       })
     })
 
+    it('should accept templates-api key format', function(done) {
+      KeyBuilder.getConvertedFolderKey.returns(
+        '5ecba29f1a294e007d0bccb4/v/0/pdf'
+      )
+      FileHandler.insertFile(bucket, key, stream, err => {
+        expect(err).not.to.exist
+        done()
+      })
+    })
+
     it('should throw an error when the key is in the wrong format', function(done) {
       KeyBuilder.getConvertedFolderKey.returns('wombat')
       FileHandler.insertFile(bucket, key, stream, err => {
@@ -153,6 +163,16 @@ describe('FileHandler', function() {
         expect(err).not.to.exist
         expect(PersistorManager.promises.deleteDirectory).not.to.have.been
           .called
+        done()
+      })
+    })
+
+    it('should accept templates-api key format', function(done) {
+      KeyBuilder.getConvertedFolderKey.returns(
+        '5ecba29f1a294e007d0bccb4/v/0/pdf'
+      )
+      FileHandler.deleteFile(bucket, key, err => {
+        expect(err).not.to.exist
         done()
       })
     })


### PR DESCRIPTION
### Description

Updates regular expression matcher for file keys to support templates API.



### Review



#### Potential Impact

Shouldn't have any, the regular expression is backwards compatible.


#### Manual Testing Performed

- [x] Check dev-environment file creation/deletion
- [x] Check Server Pro templates


#### Deployment Checklist

- [ ] Inspect file creation/deletion in staging
- [ ] Inspect file creation/deletion in production
