### PR TITLE
Fix Filestore returning one-too-many bytes when given a range

### DIFF
--- a/app/js/GcsPersistor.js
+++ b/app/js/GcsPersistor.js
@@ -115,10 +115,6 @@ async function sendStream(bucketName, key, readStream, sourceMd5) {
 
 async function getFileStream(bucketName, key, _opts = {}) {
   const opts = Object.assign({}, _opts)
-  if (opts.end) {
-    // S3 (and http range headers) treat 'end' as inclusive, so increase this by 1
-    opts.end++
-  }
   const stream = storage
     .bucket(bucketName)
     .file(key)

--- a/test/acceptance/deps/Dockerfile.fake-gcs
+++ b/test/acceptance/deps/Dockerfile.fake-gcs
@@ -1,4 +1,4 @@
-FROM fsouza/fake-gcs-server:1.18.4
+FROM fsouza/fake-gcs-server:latest
 RUN apk add --update --no-cache curl
 COPY healthcheck.sh /healthcheck.sh
 HEALTHCHECK --interval=1s --timeout=1s --retries=30 CMD /healthcheck.sh http://localhost:9090

--- a/test/unit/js/GcsPersistorTests.js
+++ b/test/unit/js/GcsPersistorTests.js
@@ -196,7 +196,7 @@ describe('GcsPersistorTests', function() {
       it('passes the byte range on to GCS', function() {
         expect(GcsFile.createReadStream).to.have.been.calledWith({
           start: 5,
-          end: 11 // we increment the end because Google's 'end' is exclusive
+          end: 10
         })
       })
     })


### PR DESCRIPTION
### Description

A recent change to `fake-gcs-server` broke the filestore tests, which I initially assumed to be a bug in a newer version of the fake server. It turns out however that I'd actually matched my GCS implementation to the old, buggy behaviour.

#### Related Issues / PRs

See fsouza/fake-gcs-server#263

### Review

I've pinned `fake-gcs-server` back to `latest` rather than a specific version. Given that we caught this bug via a fake-gcs update/bugfix I think it better to leave it like this.

#### Potential Impact

Downloading files from GCS with a range header.
