### PR TITLE
Load logger module first

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,8 +1,8 @@
-const Metrics = require('metrics-sharelatex')
 const logger = require('logger-sharelatex')
+const Metrics = require('metrics-sharelatex')
 
-Metrics.initialize('filestore')
 logger.initialize('filestore')
+Metrics.initialize('filestore')
 
 const settings = require('settings-sharelatex')
 const express = require('express')


### PR DESCRIPTION
### Description

The Google trace agent wants to be loaded before other things, and it's `logger-sharelatex` that sets this up - so needs to be loaded first.
