### PR TITLE
Use METRICS_APP_NAME env var to initialise metrics, if present

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,8 +1,8 @@
 const logger = require('logger-sharelatex')
-const Metrics = require('metrics-sharelatex')
+logger.initialize(process.env.METRICS_APP_NAME || 'filestore')
 
-logger.initialize('filestore')
-Metrics.initialize('filestore')
+const Metrics = require('metrics-sharelatex')
+Metrics.initialize(process.env.METRICS_APP_NAME || 'filestore')
 
 const settings = require('settings-sharelatex')
 const express = require('express')

--- a/app.js
+++ b/app.js
@@ -1,8 +1,8 @@
-const logger = require('logger-sharelatex')
-logger.initialize(process.env.METRICS_APP_NAME || 'filestore')
-
 const Metrics = require('metrics-sharelatex')
 Metrics.initialize(process.env.METRICS_APP_NAME || 'filestore')
+
+const logger = require('logger-sharelatex')
+logger.initialize(process.env.METRICS_APP_NAME || 'filestore')
 
 const settings = require('settings-sharelatex')
 const express = require('express')


### PR DESCRIPTION
# Description

If pressent, use `METRICS_APP_NAME` env var to initialise logging and metrics, instead of the default `filestore`.

This allows us to generate profiling data from filestore-readonly and filestore separately, which is useful in some cases as the apps are used quite differently.

### Review

This also initialises the logging module before requiring the metrics module, in case this helps with the error where initialising the trace agent complains because some modules have already been loaded. I haven't tested if this solves that problem, but I don't think it can hurt.

#### Potential Impact

This only does something if `METRICS_APP_NAME` is set, which needs to be set explicitly in the jinja file. Will need a separate google-ops PR for that.

### Deployment

Should be deployed alongside https://github.com/overleaf/google-ops/pull/1162

### Monitoring & Metrics

May affect how metrics are reported. Check the dashboards in stackdriver.