### PR TITLE
Move @google-cloud/storage to a dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -695,7 +695,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.1.2.tgz",
       "integrity": "sha512-j2blsBVv6Tt5Z7ff6kOSIg5zVQPdlcTQh/4zMb9h7xMj4ekwndQA60le8c1KEa+Y6SR3EM6ER2AvKYK53P7vdQ==",
-      "dev": true,
       "requires": {
         "@google-cloud/common": "^3.0.0",
         "@google-cloud/paginator": "^3.0.0",
@@ -725,7 +724,6 @@
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.3.2.tgz",
           "integrity": "sha512-W7JRLBEJWYtZQQuGQX06U6GBOSLrSrlvZxv6kGNwJtFrusu6AVgZltQ9Pajuz9Dh9aSXy9aTnBcyxn2/O0EGUw==",
-          "dev": true,
           "requires": {
             "@google-cloud/projectify": "^2.0.0",
             "@google-cloud/promisify": "^2.0.0",
@@ -742,7 +740,6 @@
               "version": "4.1.1",
               "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
               "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
-              "dev": true,
               "requires": {
                 "end-of-stream": "^1.4.1",
                 "inherits": "^2.0.3",
@@ -756,7 +753,6 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.2.tgz",
           "integrity": "sha512-kXK+Dbz4pNvv8bKU80Aw5HsIdgOe0WuMTd8/fI6tkANUxzvJOVJQQRsWVqcHSWK2RXHPTA9WBniUCwY6gAJDXw==",
-          "dev": true,
           "requires": {
             "arrify": "^2.0.0",
             "extend": "^3.0.2"
@@ -765,26 +761,22 @@
         "@google-cloud/projectify": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.0.1.tgz",
-          "integrity": "sha512-ZDG38U/Yy6Zr21LaR3BTiiLtpJl6RkPS/JwoRT453G+6Q1DhlV0waNf8Lfu+YVYGIIxgKnLayJRfYlFJfiI8iQ==",
-          "dev": true
+          "integrity": "sha512-ZDG38U/Yy6Zr21LaR3BTiiLtpJl6RkPS/JwoRT453G+6Q1DhlV0waNf8Lfu+YVYGIIxgKnLayJRfYlFJfiI8iQ=="
         },
         "@google-cloud/promisify": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.2.tgz",
-          "integrity": "sha512-EvuabjzzZ9E2+OaYf+7P9OAiiwbTxKYL0oGLnREQd+Su2NTQBpomkdlkBowFvyWsaV0d1sSGxrKpSNcrhPqbxg==",
-          "dev": true
+          "integrity": "sha512-EvuabjzzZ9E2+OaYf+7P9OAiiwbTxKYL0oGLnREQd+Su2NTQBpomkdlkBowFvyWsaV0d1sSGxrKpSNcrhPqbxg=="
         },
         "bignumber.js": {
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
-          "dev": true
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
         },
         "gaxios": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.0.4.tgz",
           "integrity": "sha512-97NmFuMETFQh6gqPUxkqjxRMjmY8aRKRMphIkgO/b90AbCt5wAVuXsp8oWjIXlLN2pIK/fsXD8edcM7ULkFMLg==",
-          "dev": true,
           "requires": {
             "abort-controller": "^3.0.0",
             "extend": "^3.0.2",
@@ -797,7 +789,6 @@
           "version": "4.1.4",
           "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.1.4.tgz",
           "integrity": "sha512-5J/GIH0yWt/56R3dNaNWPGQ/zXsZOddYECfJaqxFWgrZ9HC2Kvc5vl9upOgUUHKzURjAVf2N+f6tEJiojqXUuA==",
-          "dev": true,
           "requires": {
             "gaxios": "^3.0.0",
             "json-bigint": "^1.0.0"
@@ -807,7 +798,6 @@
           "version": "6.0.5",
           "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.0.5.tgz",
           "integrity": "sha512-Wj31lfTm2yR4g3WfOOB1Am1tt478Xq9OvzTPQJi17tn/I9R5IcsxjANBsE93nYmxYxtwDedhOdIb8l3vSPG49Q==",
-          "dev": true,
           "requires": {
             "arrify": "^2.0.0",
             "base64-js": "^1.3.0",
@@ -824,7 +814,6 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.2.tgz",
           "integrity": "sha512-tbjzndQvSIHGBLzHnhDs3cL4RBjLbLXc2pYvGH+imGVu5b4RMAttUTdnmW2UH0t11QeBTXZ7wlXPS7hrypO/tg==",
-          "dev": true,
           "requires": {
             "node-forge": "^0.9.0"
           }
@@ -833,7 +822,6 @@
           "version": "5.0.2",
           "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.2.tgz",
           "integrity": "sha512-lull70rHCTvRTmAt+R/6W5bTtx4MjHku7AwJwK5fGqhOmygcZud0nrZcX+QUNfBJwCzqy7S5i1Bc4NYnr5PMMA==",
-          "dev": true,
           "requires": {
             "gaxios": "^3.0.0",
             "google-p12-pem": "^3.0.0",
@@ -845,7 +833,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
           "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-          "dev": true,
           "requires": {
             "bignumber.js": "^9.0.0"
           }
@@ -854,7 +841,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -862,14 +848,12 @@
         "mime": {
           "version": "2.4.6",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-          "dev": true
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
         },
         "p-limit": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
           "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
-          "dev": true,
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -878,7 +862,6 @@
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -889,7 +872,6 @@
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.0.0.tgz",
           "integrity": "sha512-kWD3sdGmIix6w7c8ZdVKxWq+3YwVPGWz+Mq0wRZXayEKY/YHb63b8uphfBzcFDmyq8frD9+UTc3wLyOhltRbtg==",
-          "dev": true,
           "requires": {
             "http-proxy-agent": "^4.0.0",
             "https-proxy-agent": "^5.0.0",
@@ -902,7 +884,6 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
           "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-          "dev": true,
           "requires": {
             "readable-stream": "3"
           }
@@ -910,14 +891,12 @@
         "uuid": {
           "version": "8.2.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
-          "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==",
-          "dev": true
+          "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
         },
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -1168,12 +1147,12 @@
       "integrity": "sha512-LsM2s6Iy9G97ktPo0ys4VxtI/m3ahc1ZHwjo5XnhXtjeIkkkVAehsrcRRoV/yWepPjymB0oZonhcfojpjYR/tg=="
     },
     "@overleaf/object-persistor": {
-      "version": "git+https://github.com/overleaf/object-persistor.git#923c26a04dfeb9e79caaa5133394678253b5d006",
+      "version": "git+https://github.com/overleaf/object-persistor.git#8b8bc4b8d1e8b8aa3ca9245691d6ddd69d663d06",
       "from": "git+https://github.com/overleaf/object-persistor.git",
       "requires": {
-        "@google-cloud/storage": "^5.1.1",
+        "@google-cloud/storage": "^5.1.2",
         "@overleaf/o-error": "^3.0.0",
-        "aws-sdk": "^2.710.0",
+        "aws-sdk": "^2.718.0",
         "fast-crc32c": "^2.0.0",
         "glob": "^7.1.6",
         "logger-sharelatex": "^2.1.1",
@@ -1182,192 +1161,26 @@
         "tiny-async-pool": "^1.1.0"
       },
       "dependencies": {
-        "@google-cloud/common": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.3.1.tgz",
-          "integrity": "sha512-bJamcNvZ2j5xS01uFBT1GqfHIKrtwpyUhIU/Xn3uwMZkK/t6JA3mlID0wuZlo7XjbjFSRT2iLBEmDWv9T2hP8g==",
+        "aws-sdk": {
+          "version": "2.718.0",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.718.0.tgz",
+          "integrity": "sha512-YMWR1RJ3VuSbUOGeOfDw2QqRzwX51oa9TCm2G6SW+JywJUy0FTxi/Nj0VjVEQvKC0GqGu5QCgUTaarF7S0nQdw==",
           "requires": {
-            "@google-cloud/projectify": "^2.0.0",
-            "@google-cloud/promisify": "^2.0.0",
-            "arrify": "^2.0.1",
-            "duplexify": "^4.1.1",
-            "ent": "^2.2.0",
-            "extend": "^3.0.2",
-            "google-auth-library": "^6.0.0",
-            "retry-request": "^4.1.1",
-            "teeny-request": "^7.0.0"
-          },
-          "dependencies": {
-            "duplexify": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
-              "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
-              "requires": {
-                "end-of-stream": "^1.4.1",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1",
-                "stream-shift": "^1.0.0"
-              }
-            }
-          }
-        },
-        "@google-cloud/paginator": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.1.tgz",
-          "integrity": "sha512-ykqRmHRg6rcIZTE+JjUMNBKOQ8uvmbVrhY//lTxZgf5QBPbZW3PoN7VK+D43yCaRJJjRmmWsaG5YdxLR6h0n0A==",
-          "requires": {
-            "arrify": "^2.0.0",
-            "extend": "^3.0.2"
-          }
-        },
-        "@google-cloud/projectify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.0.0.tgz",
-          "integrity": "sha512-7wZ+m4N3Imtb5afOPfqNFyj9cKrlfVQ+t5YRxLS7tUpn8Pn/i7QuVubZRTXllaWjO4T5t/gm/r2x7oy5ajjvFQ=="
-        },
-        "@google-cloud/promisify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.1.tgz",
-          "integrity": "sha512-82EQzwrNauw1fkbUSr3f+50Bcq7g4h0XvLOk8C5e9ABkXYHei7ZPi9tiMMD7Vh3SfcdH97d1ibJ3KBWp2o1J+w=="
-        },
-        "@google-cloud/storage": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.1.1.tgz",
-          "integrity": "sha512-w/64V+eJl+vpYUXT15sBcO8pX0KTmb9Ni2ZNuQQ8HmyhAbEA3//G8JFaLPCXGBWO2/b0OQZytUT6q2wII9a9aQ==",
-          "requires": {
-            "@google-cloud/common": "^3.0.0",
-            "@google-cloud/paginator": "^3.0.0",
-            "@google-cloud/promisify": "^2.0.0",
-            "arrify": "^2.0.0",
-            "compressible": "^2.0.12",
-            "concat-stream": "^2.0.0",
-            "date-and-time": "^0.13.0",
-            "duplexify": "^3.5.0",
-            "extend": "^3.0.2",
-            "gaxios": "^3.0.0",
-            "gcs-resumable-upload": "^3.0.0",
-            "hash-stream-validation": "^0.2.2",
-            "mime": "^2.2.0",
-            "mime-types": "^2.0.8",
-            "onetime": "^5.1.0",
-            "p-limit": "^3.0.1",
-            "pumpify": "^2.0.0",
-            "readable-stream": "^3.4.0",
-            "snakeize": "^0.1.0",
-            "stream-events": "^1.0.1",
-            "through2": "^3.0.0",
-            "xdg-basedir": "^4.0.0"
-          }
-        },
-        "gaxios": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.0.3.tgz",
-          "integrity": "sha512-PkzQludeIFhd535/yucALT/Wxyj/y2zLyrMwPcJmnLHDugmV49NvAi/vb+VUq/eWztATZCNcb8ue+ywPG+oLuw==",
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "extend": "^3.0.2",
-            "https-proxy-agent": "^5.0.0",
-            "is-stream": "^2.0.0",
-            "node-fetch": "^2.3.0"
-          }
-        },
-        "gcp-metadata": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.1.0.tgz",
-          "integrity": "sha512-r57SV28+olVsflPlKyVig3Muo/VDlcsObMtvDGOEtEJXj+DDE8bEl0coIkXh//hbkSDTvo+f5lbihZOndYXQQQ==",
-          "requires": {
-            "gaxios": "^3.0.0",
-            "json-bigint": "^0.3.0"
-          }
-        },
-        "gcs-resumable-upload": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.1.0.tgz",
-          "integrity": "sha512-gB8xH6EjYCv9lfBEL4FK5+AMgTY0feYoNHAYOV5nCuOrDPhy5MOiyJE8WosgxhbKBPS361H7fkwv6CTufEh9bg==",
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "configstore": "^5.0.0",
-            "extend": "^3.0.2",
-            "gaxios": "^3.0.0",
-            "google-auth-library": "^6.0.0",
-            "pumpify": "^2.0.0",
-            "stream-events": "^1.0.4"
-          }
-        },
-        "google-auth-library": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.0.3.tgz",
-          "integrity": "sha512-2Np6ojPmaJGXHSMsBhtTQEKfSMdLc8hefoihv7N2cwEr8E5bq39fhoat6TcXHwa0XoGO5Guh9sp3nxHFPmibMw==",
-          "requires": {
-            "arrify": "^2.0.0",
-            "base64-js": "^1.3.0",
-            "ecdsa-sig-formatter": "^1.0.11",
-            "fast-text-encoding": "^1.0.0",
-            "gaxios": "^3.0.0",
-            "gcp-metadata": "^4.1.0",
-            "gtoken": "^5.0.0",
-            "jws": "^4.0.0",
-            "lru-cache": "^5.0.0"
-          }
-        },
-        "google-p12-pem": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.1.tgz",
-          "integrity": "sha512-VlQgtozgNVVVcYTXS36eQz4PXPt9gIPqLOhHN0QiV6W6h4qSCNVKPtKC5INtJsaHHF2r7+nOIa26MJeJMTaZEQ==",
-          "requires": {
-            "node-forge": "^0.9.0"
-          }
-        },
-        "gtoken": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.1.tgz",
-          "integrity": "sha512-33w4FNDkUcyIOq/TqyC+drnKdI4PdXmWp9lZzssyEQKuvu9ZFN3KttaSnDKo52U3E51oujVGop93mKxmqO8HHg==",
-          "requires": {
-            "gaxios": "^3.0.0",
-            "google-p12-pem": "^3.0.0",
-            "jws": "^4.0.0",
-            "mime": "^2.2.0"
-          }
-        },
-        "mime": {
-          "version": "2.4.6",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
-        },
-        "p-limit": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.1.tgz",
-          "integrity": "sha512-mw/p92EyOzl2MhauKodw54Rx5ZK4624rNfgNaBguFZkHzyUG9WsDzFF5/yQVEJinbJDdP4jEfMN+uBquiGnaLg==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "teeny-request": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.0.0.tgz",
-          "integrity": "sha512-kWD3sdGmIix6w7c8ZdVKxWq+3YwVPGWz+Mq0wRZXayEKY/YHb63b8uphfBzcFDmyq8frD9+UTc3wLyOhltRbtg==",
-          "requires": {
-            "http-proxy-agent": "^4.0.0",
-            "https-proxy-agent": "^5.0.0",
-            "node-fetch": "^2.2.0",
-            "stream-events": "^1.0.5",
-            "uuid": "^8.0.0"
+            "buffer": "4.9.2",
+            "events": "1.1.1",
+            "ieee754": "1.1.13",
+            "jmespath": "0.15.0",
+            "querystring": "0.2.0",
+            "sax": "1.2.1",
+            "url": "0.10.3",
+            "uuid": "3.3.2",
+            "xml2js": "0.4.19"
           }
         },
         "uuid": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
-          "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
       }
     },
@@ -1817,9 +1630,10 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "aws-sdk": {
-      "version": "2.710.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.710.0.tgz",
-      "integrity": "sha512-GQTPH0DzJMpvvtZ3VO+grkKVdL/nqjWsIfcVf1c3oedvEjW24wSXQEs6KWAGbpG2jbHsYKH7kZ4XXuq428LVAw==",
+      "version": "2.718.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.718.0.tgz",
+      "integrity": "sha512-YMWR1RJ3VuSbUOGeOfDw2QqRzwX51oa9TCm2G6SW+JywJUy0FTxi/Nj0VjVEQvKC0GqGu5QCgUTaarF7S0nQdw==",
+      "dev": true,
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -1835,7 +1649,8 @@
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "dev": true
         }
       }
     },
@@ -3246,7 +3061,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.1.1.tgz",
       "integrity": "sha512-RS1osvAicj9+MjCc6jAcVL1Pt3tg7NK2C2gXM5nqD1Gs0klF2kj5nnAFSBy97JrtslMIQzpb7iSuxaG8rFWd2A==",
-      "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "configstore": "^5.0.0",
@@ -3260,14 +3074,12 @@
         "bignumber.js": {
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
-          "dev": true
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
         },
         "gaxios": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.0.4.tgz",
           "integrity": "sha512-97NmFuMETFQh6gqPUxkqjxRMjmY8aRKRMphIkgO/b90AbCt5wAVuXsp8oWjIXlLN2pIK/fsXD8edcM7ULkFMLg==",
-          "dev": true,
           "requires": {
             "abort-controller": "^3.0.0",
             "extend": "^3.0.2",
@@ -3280,7 +3092,6 @@
           "version": "4.1.4",
           "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.1.4.tgz",
           "integrity": "sha512-5J/GIH0yWt/56R3dNaNWPGQ/zXsZOddYECfJaqxFWgrZ9HC2Kvc5vl9upOgUUHKzURjAVf2N+f6tEJiojqXUuA==",
-          "dev": true,
           "requires": {
             "gaxios": "^3.0.0",
             "json-bigint": "^1.0.0"
@@ -3290,7 +3101,6 @@
           "version": "6.0.5",
           "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.0.5.tgz",
           "integrity": "sha512-Wj31lfTm2yR4g3WfOOB1Am1tt478Xq9OvzTPQJi17tn/I9R5IcsxjANBsE93nYmxYxtwDedhOdIb8l3vSPG49Q==",
-          "dev": true,
           "requires": {
             "arrify": "^2.0.0",
             "base64-js": "^1.3.0",
@@ -3307,7 +3117,6 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.2.tgz",
           "integrity": "sha512-tbjzndQvSIHGBLzHnhDs3cL4RBjLbLXc2pYvGH+imGVu5b4RMAttUTdnmW2UH0t11QeBTXZ7wlXPS7hrypO/tg==",
-          "dev": true,
           "requires": {
             "node-forge": "^0.9.0"
           }
@@ -3316,7 +3125,6 @@
           "version": "5.0.2",
           "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.2.tgz",
           "integrity": "sha512-lull70rHCTvRTmAt+R/6W5bTtx4MjHku7AwJwK5fGqhOmygcZud0nrZcX+QUNfBJwCzqy7S5i1Bc4NYnr5PMMA==",
-          "dev": true,
           "requires": {
             "gaxios": "^3.0.0",
             "google-p12-pem": "^3.0.0",
@@ -3328,7 +3136,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
           "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-          "dev": true,
           "requires": {
             "bignumber.js": "^9.0.0"
           }
@@ -3337,7 +3144,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -3345,14 +3151,12 @@
         "mime": {
           "version": "2.4.6",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-          "dev": true
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
         },
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -692,13 +692,14 @@
       "integrity": "sha512-VccZDcOql77obTnFh0TbNED/6ZbbmHDf8UMNnzO1d5g9V0Htfm4k5cllY8P1tJsRKC3zWYGRLaViiupcgVjBoQ=="
     },
     "@google-cloud/storage": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-4.7.0.tgz",
-      "integrity": "sha512-f0guAlbeg7Z0m3gKjCfBCu7FG9qS3M3oL5OQQxlvGoPtK7/qg3+W+KQV73O2/sbuS54n0Kh2mvT5K2FWzF5vVQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.1.2.tgz",
+      "integrity": "sha512-j2blsBVv6Tt5Z7ff6kOSIg5zVQPdlcTQh/4zMb9h7xMj4ekwndQA60le8c1KEa+Y6SR3EM6ER2AvKYK53P7vdQ==",
+      "dev": true,
       "requires": {
-        "@google-cloud/common": "^2.1.1",
-        "@google-cloud/paginator": "^2.0.0",
-        "@google-cloud/promisify": "^1.0.0",
+        "@google-cloud/common": "^3.0.0",
+        "@google-cloud/paginator": "^3.0.0",
+        "@google-cloud/promisify": "^2.0.0",
         "arrify": "^2.0.0",
         "compressible": "^2.0.12",
         "concat-stream": "^2.0.0",
@@ -706,24 +707,84 @@
         "duplexify": "^3.5.0",
         "extend": "^3.0.2",
         "gaxios": "^3.0.0",
-        "gcs-resumable-upload": "^2.2.4",
+        "gcs-resumable-upload": "^3.0.0",
         "hash-stream-validation": "^0.2.2",
         "mime": "^2.2.0",
         "mime-types": "^2.0.8",
         "onetime": "^5.1.0",
-        "p-limit": "^2.2.0",
+        "p-limit": "^3.0.1",
         "pumpify": "^2.0.0",
         "readable-stream": "^3.4.0",
         "snakeize": "^0.1.0",
         "stream-events": "^1.0.1",
-        "through2": "^3.0.0",
+        "through2": "^4.0.0",
         "xdg-basedir": "^4.0.0"
       },
       "dependencies": {
-        "gaxios": {
+        "@google-cloud/common": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.3.2.tgz",
+          "integrity": "sha512-W7JRLBEJWYtZQQuGQX06U6GBOSLrSrlvZxv6kGNwJtFrusu6AVgZltQ9Pajuz9Dh9aSXy9aTnBcyxn2/O0EGUw==",
+          "dev": true,
+          "requires": {
+            "@google-cloud/projectify": "^2.0.0",
+            "@google-cloud/promisify": "^2.0.0",
+            "arrify": "^2.0.1",
+            "duplexify": "^4.1.1",
+            "ent": "^2.2.0",
+            "extend": "^3.0.2",
+            "google-auth-library": "^6.0.0",
+            "retry-request": "^4.1.1",
+            "teeny-request": "^7.0.0"
+          },
+          "dependencies": {
+            "duplexify": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
+              "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+              "dev": true,
+              "requires": {
+                "end-of-stream": "^1.4.1",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1",
+                "stream-shift": "^1.0.0"
+              }
+            }
+          }
+        },
+        "@google-cloud/paginator": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.0.2.tgz",
-          "integrity": "sha512-cLOetrsKOBLPwjzVyFzirYaGjrhtYjbKUHp6fQpsio2HH8Mil35JTFQLgkV5D3CCXV7Gnd5V69/m4C9rMBi9bA==",
+          "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.2.tgz",
+          "integrity": "sha512-kXK+Dbz4pNvv8bKU80Aw5HsIdgOe0WuMTd8/fI6tkANUxzvJOVJQQRsWVqcHSWK2RXHPTA9WBniUCwY6gAJDXw==",
+          "dev": true,
+          "requires": {
+            "arrify": "^2.0.0",
+            "extend": "^3.0.2"
+          }
+        },
+        "@google-cloud/projectify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.0.1.tgz",
+          "integrity": "sha512-ZDG38U/Yy6Zr21LaR3BTiiLtpJl6RkPS/JwoRT453G+6Q1DhlV0waNf8Lfu+YVYGIIxgKnLayJRfYlFJfiI8iQ==",
+          "dev": true
+        },
+        "@google-cloud/promisify": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.2.tgz",
+          "integrity": "sha512-EvuabjzzZ9E2+OaYf+7P9OAiiwbTxKYL0oGLnREQd+Su2NTQBpomkdlkBowFvyWsaV0d1sSGxrKpSNcrhPqbxg==",
+          "dev": true
+        },
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+          "dev": true
+        },
+        "gaxios": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.0.4.tgz",
+          "integrity": "sha512-97NmFuMETFQh6gqPUxkqjxRMjmY8aRKRMphIkgO/b90AbCt5wAVuXsp8oWjIXlLN2pIK/fsXD8edcM7ULkFMLg==",
+          "dev": true,
           "requires": {
             "abort-controller": "^3.0.0",
             "extend": "^3.0.2",
@@ -732,20 +793,131 @@
             "node-fetch": "^2.3.0"
           }
         },
+        "gcp-metadata": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.1.4.tgz",
+          "integrity": "sha512-5J/GIH0yWt/56R3dNaNWPGQ/zXsZOddYECfJaqxFWgrZ9HC2Kvc5vl9upOgUUHKzURjAVf2N+f6tEJiojqXUuA==",
+          "dev": true,
+          "requires": {
+            "gaxios": "^3.0.0",
+            "json-bigint": "^1.0.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.0.5.tgz",
+          "integrity": "sha512-Wj31lfTm2yR4g3WfOOB1Am1tt478Xq9OvzTPQJi17tn/I9R5IcsxjANBsE93nYmxYxtwDedhOdIb8l3vSPG49Q==",
+          "dev": true,
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^3.0.0",
+            "gcp-metadata": "^4.1.0",
+            "gtoken": "^5.0.0",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "google-p12-pem": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.2.tgz",
+          "integrity": "sha512-tbjzndQvSIHGBLzHnhDs3cL4RBjLbLXc2pYvGH+imGVu5b4RMAttUTdnmW2UH0t11QeBTXZ7wlXPS7hrypO/tg==",
+          "dev": true,
+          "requires": {
+            "node-forge": "^0.9.0"
+          }
+        },
+        "gtoken": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.2.tgz",
+          "integrity": "sha512-lull70rHCTvRTmAt+R/6W5bTtx4MjHku7AwJwK5fGqhOmygcZud0nrZcX+QUNfBJwCzqy7S5i1Bc4NYnr5PMMA==",
+          "dev": true,
+          "requires": {
+            "gaxios": "^3.0.0",
+            "google-p12-pem": "^3.0.0",
+            "jws": "^4.0.0",
+            "mime": "^2.2.0"
+          }
+        },
+        "json-bigint": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+          "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+          "dev": true,
+          "requires": {
+            "bignumber.js": "^9.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "mime": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+          "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
         },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
           }
+        },
+        "teeny-request": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.0.0.tgz",
+          "integrity": "sha512-kWD3sdGmIix6w7c8ZdVKxWq+3YwVPGWz+Mq0wRZXayEKY/YHb63b8uphfBzcFDmyq8frD9+UTc3wLyOhltRbtg==",
+          "dev": true,
+          "requires": {
+            "http-proxy-agent": "^4.0.0",
+            "https-proxy-agent": "^5.0.0",
+            "node-fetch": "^2.2.0",
+            "stream-events": "^1.0.5",
+            "uuid": "^8.0.0"
+          }
+        },
+        "through2": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+          "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "3"
+          }
+        },
+        "uuid": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
+          "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
         }
       }
     },
@@ -3071,16 +3243,117 @@
       }
     },
     "gcs-resumable-upload": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-2.3.3.tgz",
-      "integrity": "sha512-sf896I5CC/1AxeaGfSFg3vKMjUq/r+A3bscmVzZm10CElyRanN0XwPu/MxeIO4LSP+9uF6yKzXvNsaTsMXUG6Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.1.1.tgz",
+      "integrity": "sha512-RS1osvAicj9+MjCc6jAcVL1Pt3tg7NK2C2gXM5nqD1Gs0klF2kj5nnAFSBy97JrtslMIQzpb7iSuxaG8rFWd2A==",
+      "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "configstore": "^5.0.0",
-        "gaxios": "^2.0.0",
-        "google-auth-library": "^5.0.0",
+        "extend": "^3.0.2",
+        "gaxios": "^3.0.0",
+        "google-auth-library": "^6.0.0",
         "pumpify": "^2.0.0",
         "stream-events": "^1.0.4"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+          "dev": true
+        },
+        "gaxios": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.0.4.tgz",
+          "integrity": "sha512-97NmFuMETFQh6gqPUxkqjxRMjmY8aRKRMphIkgO/b90AbCt5wAVuXsp8oWjIXlLN2pIK/fsXD8edcM7ULkFMLg==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.3.0"
+          }
+        },
+        "gcp-metadata": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.1.4.tgz",
+          "integrity": "sha512-5J/GIH0yWt/56R3dNaNWPGQ/zXsZOddYECfJaqxFWgrZ9HC2Kvc5vl9upOgUUHKzURjAVf2N+f6tEJiojqXUuA==",
+          "dev": true,
+          "requires": {
+            "gaxios": "^3.0.0",
+            "json-bigint": "^1.0.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.0.5.tgz",
+          "integrity": "sha512-Wj31lfTm2yR4g3WfOOB1Am1tt478Xq9OvzTPQJi17tn/I9R5IcsxjANBsE93nYmxYxtwDedhOdIb8l3vSPG49Q==",
+          "dev": true,
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^3.0.0",
+            "gcp-metadata": "^4.1.0",
+            "gtoken": "^5.0.0",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "google-p12-pem": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.2.tgz",
+          "integrity": "sha512-tbjzndQvSIHGBLzHnhDs3cL4RBjLbLXc2pYvGH+imGVu5b4RMAttUTdnmW2UH0t11QeBTXZ7wlXPS7hrypO/tg==",
+          "dev": true,
+          "requires": {
+            "node-forge": "^0.9.0"
+          }
+        },
+        "gtoken": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.2.tgz",
+          "integrity": "sha512-lull70rHCTvRTmAt+R/6W5bTtx4MjHku7AwJwK5fGqhOmygcZud0nrZcX+QUNfBJwCzqy7S5i1Bc4NYnr5PMMA==",
+          "dev": true,
+          "requires": {
+            "gaxios": "^3.0.0",
+            "google-p12-pem": "^3.0.0",
+            "jws": "^4.0.0",
+            "mime": "^2.2.0"
+          }
+        },
+        "json-bigint": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+          "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+          "dev": true,
+          "requires": {
+            "bignumber.js": "^9.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "mime": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "get-caller-file": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "test:unit:_run": "mocha --recursive --reporter spec $@ test/unit/js"
   },
   "dependencies": {
-    "@google-cloud/storage": "^4.7.0",
     "@overleaf/o-error": "^3.0.0",
     "@overleaf/object-persistor": "git+https://github.com/overleaf/object-persistor.git",
     "aws-sdk": "^2.710.0",
@@ -40,6 +39,7 @@
     "tiny-async-pool": "^1.1.0"
   },
   "devDependencies": {
+    "@google-cloud/storage": "^5.1.2",
     "babel-eslint": "^10.1.0",
     "bunyan": "^1.8.14",
     "chai": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@overleaf/o-error": "^3.0.0",
     "@overleaf/object-persistor": "git+https://github.com/overleaf/object-persistor.git",
-    "aws-sdk": "^2.710.0",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "fast-crc32c": "^2.0.0",
@@ -40,6 +39,7 @@
   },
   "devDependencies": {
     "@google-cloud/storage": "^5.1.2",
+    "aws-sdk": "^2.718.0",
     "babel-eslint": "^10.1.0",
     "bunyan": "^1.8.14",
     "chai": "4.2.0",


### PR DESCRIPTION
### Description

`@google-cloud/storage` is no longer directly used by Filestore, and is instead pulled in by `object-persistor` which is pulling in a different version.

It's still used by the acceptance tests, so I've upgraded this and made it a dev dependency instead.

### Review

It's already been tested with a canary deploy.

No hash downgrades in package-lock! :tada: