### PR TITLE
Upgrade object-persistor to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1120,7 +1120,7 @@
       "integrity": "sha512-LsM2s6Iy9G97ktPo0ys4VxtI/m3ahc1ZHwjo5XnhXtjeIkkkVAehsrcRRoV/yWepPjymB0oZonhcfojpjYR/tg=="
     },
     "@overleaf/object-persistor": {
-      "version": "git+https://github.com/overleaf/object-persistor.git#8b8bc4b8d1e8b8aa3ca9245691d6ddd69d663d06",
+      "version": "git+https://github.com/overleaf/object-persistor.git#8fbc9ed03206bfb54368578d22b7ac4f285baa25",
       "from": "git+https://github.com/overleaf/object-persistor.git",
       "requires": {
         "@google-cloud/storage": "^5.1.2",


### PR DESCRIPTION
### Description

Deleting an empty directory can cause problems in the dev environment. There is a fix here:
https://github.com/overleaf/object-persistor/pull/12

This patch pulls in that change.

#### Related Issues / PRs

Fix: https://github.com/overleaf/object-persistor/pull/12
Should unblock: https://github.com/overleaf/web-internal/pull/3269

### Review

Just a package-lock upgrade. I've checked the commit hash against the head of master in object-persistor.

#### Potential Impact

Should be fairly limited.
