### PR TITLE
Upgrade build-scripts to 3.4.0

### DIFF
--- a/buildscript.txt
+++ b/buildscript.txt
@@ -6,4 +6,4 @@ filestore
 --env-pass-through=
 --node-version=12.18.4
 --public-repo=True
---script-version=3.3.4
+--script-version=3.4.0

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -20,6 +20,7 @@ services:
     environment:
       ELASTIC_SEARCH_DSN: es:9200
       REDIS_HOST: redis
+      QUEUES_REDIS_HOST: redis
       MONGO_HOST: mongo
       POSTGRES_HOST: postgres
       AWS_S3_ENDPOINT: http://s3:9090
@@ -58,12 +59,17 @@ services:
     command: tar -czf /tmp/build/build.tar.gz --exclude=build.tar.gz --exclude-vcs .
     user: root
   s3:
-    build:
-      context: test/acceptance/deps
-      dockerfile: Dockerfile.s3mock
+    image: adobe/s3mock
     environment:
       - initialBuckets=fake_user_files,fake_template_files,fake_public_files,bucket
+    healthcheck:
+      test: wget --quiet --output-document=/dev/null http://localhost:9090
+      interval: 1s
+      retries: 20
   gcs:
-    build:
-      context: test/acceptance/deps
-      dockerfile: Dockerfile.fake-gcs
+    image: fsouza/fake-gcs-server
+    command: ["--port=9090", "--scheme=http"]
+    healthcheck:
+      test: wget --quiet --output-document=/dev/null http://localhost:9090/storage/v1/b
+      interval: 1s
+      retries: 20

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     environment:
       ELASTIC_SEARCH_DSN: es:9200
       REDIS_HOST: redis
+      QUEUES_REDIS_HOST: redis
       MONGO_HOST: mongo
       POSTGRES_HOST: postgres
       AWS_S3_ENDPOINT: http://s3:9090
@@ -60,12 +61,17 @@ services:
     command: npm run --silent test:acceptance
 
   s3:
-    build:
-      context: test/acceptance/deps
-      dockerfile: Dockerfile.s3mock
+    image: adobe/s3mock
     environment:
       - initialBuckets=fake_user_files,fake_template_files,fake_public_files,bucket
+    healthcheck:
+      test: wget --quiet --output-document=/dev/null http://localhost:9090
+      interval: 1s
+      retries: 20
   gcs:
-    build:
-      context: test/acceptance/deps
-      dockerfile: Dockerfile.fake-gcs
+    image: fsouza/fake-gcs-server
+    command: ["--port=9090", "--scheme=http"]
+    healthcheck:
+      test: wget --quiet --output-document=/dev/null http://localhost:9090/storage/v1/b
+      interval: 1s
+      retries: 20


### PR DESCRIPTION
This version fixes docker-compose health checks for dependent services. See
https://github.com/overleaf/dev-environment/pull/409 for details.