### PR TITLE
[misc] install @overleaf/object-persistor from tar-ball

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -833,8 +833,8 @@
       "integrity": "sha512-LsM2s6Iy9G97ktPo0ys4VxtI/m3ahc1ZHwjo5XnhXtjeIkkkVAehsrcRRoV/yWepPjymB0oZonhcfojpjYR/tg=="
     },
     "@overleaf/object-persistor": {
-      "version": "git+https://github.com/overleaf/object-persistor.git#8fbc9ed03206bfb54368578d22b7ac4f285baa25",
-      "from": "git+https://github.com/overleaf/object-persistor.git",
+      "version": "https://github.com/overleaf/object-persistor/archive/8fbc9ed03206bfb54368578d22b7ac4f285baa25.tar.gz",
+      "integrity": "sha512-QApK1xZv4c2sco4lBwq5tn2w7ZNcnqQ/bVPbrxpiJCK5L5Gfvwcm0T2cAbbsuI/FSkSB93eU60iZqPtT87vp9w==",
       "requires": {
         "@google-cloud/storage": "^5.1.2",
         "@overleaf/o-error": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@overleaf/metrics": "^3.4.1",
     "@overleaf/o-error": "^3.0.0",
-    "@overleaf/object-persistor": "git+https://github.com/overleaf/object-persistor.git",
+    "@overleaf/object-persistor": "https://github.com/overleaf/object-persistor/archive/8fbc9ed03206bfb54368578d22b7ac4f285baa25.tar.gz",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "fast-crc32c": "^2.0.0",


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3731

Installing npm packages via git is flaky (https://github.com/overleaf/third-party-references/pull/42).
This PR is switching the installation of the @overleaf/object-persistor package to a tar-ball install.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3731

#### Potential Impact

Low. The tests are not working without this package being properly installed, so the chance of it breaking in prod are low.
