### PR TITLE
pin fake-gcs to 1.21.2 to prevent acceptance-test errors

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -67,7 +67,7 @@ services:
       interval: 1s
       retries: 20
   gcs:
-    image: fsouza/fake-gcs-server
+    image: fsouza/fake-gcs-server:v1.21.2
     command: ["--port=9090", "--scheme=http"]
     healthcheck:
       test: wget --quiet --output-document=/dev/null http://localhost:9090/storage/v1/b

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       interval: 1s
       retries: 20
   gcs:
-    image: fsouza/fake-gcs-server
+    image: fsouza/fake-gcs-server:v1.21.2
     command: ["--port=9090", "--scheme=http"]
     healthcheck:
       test: wget --quiet --output-document=/dev/null http://localhost:9090/storage/v1/b


### PR DESCRIPTION
### Description

Implementation of https://github.com/overleaf/docstore/pull/83/files for filestore.

#### Related Issues / PRs

See: https://github.com/overleaf/issues/issues/3890

Only affects ci.